### PR TITLE
fix: align test types with current interfaces

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,6 +10,8 @@ test("returns parsed config from successful response", async () => {
     minimumCost: 100,
     regressionThreshold: 0.5,
     ignoredQueryHashes: ["abc123"],
+    acknowledgedQueryHashes: [],
+    comparisonBranch: undefined,
   };
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
     Response.json(config, { status: 200 }),

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,7 +10,6 @@ test("returns parsed config from successful response", async () => {
     minimumCost: 100,
     regressionThreshold: 0.5,
     ignoredQueryHashes: ["abc123"],
-    lastSeenQueries: ["hash1"],
   };
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
     Response.json(config, { status: 200 }),
@@ -65,7 +64,7 @@ test("passes through partial response with missing optional fields", async () =>
     minimumCost: 50,
     regressionThreshold: 0.1,
     ignoredQueryHashes: [],
-    // lastSeenQueries intentionally omitted
+    // all required fields present
   };
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
     Response.json(partial, { status: 200 }),
@@ -75,20 +74,4 @@ test("passes through partial response with missing optional fields", async () =>
   expect(result.minimumCost).toBe(50);
   expect(result.regressionThreshold).toBe(0.1);
   expect(result.ignoredQueryHashes).toEqual([]);
-  expect(result.lastSeenQueries).toBeUndefined();
-});
-
-test("preserves lastSeenQueries when present in response", async () => {
-  const config = {
-    minimumCost: 0,
-    regressionThreshold: 0,
-    ignoredQueryHashes: [],
-    lastSeenQueries: ["q1", "q2"],
-  };
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    Response.json(config, { status: 200 }),
-  );
-
-  const result = await fetchAnalyzerConfig("https://api.example.com", "my/repo");
-  expect(result.lastSeenQueries).toEqual(["q1", "q2"]);
 });

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -15,6 +15,9 @@ function makeQuery(hash: string, cost: number = 100): CiQueryPayload {
       cost,
       indexesUsed: [],
     },
+    nudges: [],
+    tags: [],
+    tableReferences: [],
   };
 }
 


### PR DESCRIPTION
## Summary
- Remove references to `lastSeenQueries` in config tests — the property was removed from `AnalyzerConfig` but tests still referenced it, causing typecheck failures
- Add missing required fields (`nudges`, `tags`, `tableReferences`) to `makeQuery` helper in site-api tests to match updated `CiQueryPayload` interface

Fixes the Release Action CI failure on main caused by TypeScript errors after merging two PRs with interface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)