### PR TITLE
fix: strip sqlcommenter tags from formattedQuery

### DIFF
--- a/src/sql/recent-query.test.ts
+++ b/src/sql/recent-query.test.ts
@@ -211,6 +211,12 @@ test("analyze produces a RecentQuery with formatted query and analysis", async (
   expect(rq.tableReferences.some((ref) => ref.table === "users")).toBe(true);
 });
 
+test("analyze strips sqlcommenter tags from formattedQuery", async () => {
+  const query = "SELECT id FROM users /*traceparent='00-abc123'*/";
+  const rq = await RecentQuery.analyze(makeRawQuery({ query }), testHash, 2000);
+  expect(rq.formattedQuery).toBe("SELECT\n  id\nFROM\n  users ");
+});
+
 test("analyze throws on unparseable SQL", async () => {
   const data = makeRawQuery({ query: "THIS IS NOT VALID SQL AT ALL !!!" });
   await expect(

--- a/src/sql/recent-query.ts
+++ b/src/sql/recent-query.ts
@@ -121,11 +121,16 @@ export class RecentQuery {
     const formattedQuery = await RecentQuery.formatQuery(
       data.query,
     );
-    const analysis = await analyzer.analyze(formattedQuery);
+    const analysis = await analyzer.analyze(data.query, formattedQuery);
     const query = this.rewriteQuery(analysis.queryWithoutTags);
     const displayQuery = await RecentQuery.computeDisplayQuery(query);
     return new RecentQuery(
-      { ...data, query, formattedQuery, displayQuery },
+      {
+        ...data,
+        query,
+        formattedQuery: analysis.formattedQueryWithoutTags ?? formattedQuery,
+        displayQuery,
+      },
       analysis.referencedTables,
       analysis.indexesToCheck,
       analysis.tags,


### PR DESCRIPTION
## Summary
- `RecentQuery.analyze()` was stripping sqlcommenter tags (e.g. `/*traceparent=...*/`) from `query` via `analysis.queryWithoutTags`, but `formattedQuery` was passed through with tags still intact.
- Pass both `data.query` and `formattedQuery` to `Analyzer.analyze()` so the core library strips tags from both, and use `analysis.formattedQueryWithoutTags` for the formatted output.

## Test plan
- [x] Added test asserting `formattedQuery` output matches expected string with no sqlcommenter tags
- [x] All 20 tests in `recent-query.test.ts` pass on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)