### PR TITLE
fix: serialize prettier formatting to prevent flaky tests

### DIFF
--- a/src/sql/recent-query.ts
+++ b/src/sql/recent-query.ts
@@ -144,7 +144,8 @@ export class RecentQuery {
         language: "postgresql",
         keywordCase: "upper",
       });
-    } catch {
+    } catch (error) {
+      console.error(`[prettier] Failed to format query: ${error}`);
       return query;
     } finally {
       RecentQuery.prettierMutex.release();

--- a/src/sql/recent-query.ts
+++ b/src/sql/recent-query.ts
@@ -11,6 +11,7 @@ import {
   type TableReference,
 } from "@query-doctor/core";
 import { parse } from "@libpg-query/parser";
+import { Sema } from "async-sema";
 import z from "zod";
 import type { LiveQueryOptimization } from "../remote/optimization.ts";
 
@@ -21,6 +22,7 @@ import type { LiveQueryOptimization } from "../remote/optimization.ts";
 export class RecentQuery {
   private static HARDCODED_LIMIT = 50;
   private static rewriter = new PssRewriter();
+  private static prettierMutex = new Sema(1);
 
   readonly formattedQuery: string;
   readonly username: string;
@@ -134,6 +136,7 @@ export class RecentQuery {
   }
 
   private static async formatQuery(query: string): Promise<string> {
+    await RecentQuery.prettierMutex.acquire();
     try {
       return await prettier.format(query, {
         parser: "sql",
@@ -143,6 +146,8 @@ export class RecentQuery {
       });
     } catch {
       return query;
+    } finally {
+      RecentQuery.prettierMutex.release();
     }
   }
 


### PR DESCRIPTION
## Summary
- `prettier-plugin-sql` is not safe to call concurrently. `QueryCache.sync()` runs up to 10 `RecentQuery.analyze()` calls in parallel, each calling `prettier.format()`. Under CI load, some calls throw silently (caught by the existing try/catch), causing queries to retain their original lowercase casing instead of being uppercased — leading to non-deterministic test failures.
- Adds a mutex (`Sema(1)`) around `formatQuery` to serialize prettier calls, making output deterministic.

## Test plan
- [x] All 153 tests pass locally
- [x] Specifically verified `remote.test.ts` (8 tests) and `query-optimizer.test.ts` (5 tests) — both previously failing in the `release` CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)