### PR TITLE
fix: report unique queries (matches site) instead of log-entry count in CI comment

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -110,7 +110,7 @@ function makeContext(overrides: Partial<ReportContext> = {}): ReportContext {
     statisticsMode: { kind: "fromAssumption", reltuples: 10000 },
     recommendations: [],
     queriesPastThreshold: [],
-    queryStats: { total: 28, matched: 10, optimized: 2, errored: 0 },
+    queryStats: { analyzed: 28, matched: 10, optimized: 2, errored: 0 },
     statistics: [],
     metadata: { logSize: 1000, timeElapsed: 5000 },
     ...overrides,
@@ -323,18 +323,18 @@ describe("buildViewModel", () => {
 });
 
 describe("template rendering", () => {
-  test("renders queryStats.total as the query count", () => {
+  test("renders queryStats.analyzed as the query count", () => {
     const ctx = makeContext({
-      queryStats: { total: 5, matched: 3, optimized: 1, errored: 0 },
+      queryStats: { analyzed: 5, matched: 3, optimized: 1, errored: 0 },
       comparison: makeComparison(),
     });
     const output = renderTemplate(ctx);
     expect(output).toContain("5 queries analyzed");
   });
 
-  test("renders queryStats.total in no-comparison mode", () => {
+  test("renders queryStats.analyzed in no-comparison mode", () => {
     const ctx = makeContext({
-      queryStats: { total: 3, matched: 1, optimized: 0, errored: 0 },
+      queryStats: { analyzed: 3, matched: 1, optimized: 0, errored: 0 },
     });
     const output = renderTemplate(ctx);
     expect(output).toContain("3 queries analyzed");

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -4,10 +4,10 @@
 {% endif %}
 
 {% if hasComparison %}
-{{ queryStats.total | default('?') }} queries analyzed
+{{ queryStats.analyzed | default('?') }} queries analyzed
 {%- if newQueryCount > 0 %} | {{ newQueryCount }} new quer{{ "ies" if newQueryCount != 1 else "y" }}{% endif %}
 {% else %}
-{{ queryStats.total | default('?') }} queries analyzed — no baseline found to compare against.
+{{ queryStats.analyzed | default('?') }} queries analyzed — no baseline found to compare against.
 
 > **No baseline on `{{ comparisonBranch }}`** — the analyzer cannot detect regressions without a previous run. To establish a baseline, add a `push` trigger for your comparison branch so the analyzer runs on merges to `{{ comparisonBranch }}`. See the [CI integration guide](https://docs.querydoctor.com/guides/ci-integration/#workflow-trigger) for setup instructions.
 {% endif %}

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -62,8 +62,8 @@ export type ReportMetadata = {
 declare const s: unique symbol;
 
 export interface ReportStatistics {
-  /** Number of unique, non-filtered queries analyzed */
-  total: number;
+  /** Number of unique queries analyzed and uploaded to the site */
+  analyzed: number;
   /** Number of queries that matched the query pattern */
   matched: number;
   /** Number of queries that had an index recommendation */

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,64 +1,30 @@
 import { test, expect, describe } from "vitest";
-import { countUploadableQueries, UPLOADABLE_STATES } from "./runner.ts";
 import { buildQueries } from "./reporters/site-api.ts";
 import type { OptimizedQuery } from "./sql/recent-query.ts";
 
-function fakeQuery(state: string): OptimizedQuery {
+function fakeQuery(hash: string, state: string): OptimizedQuery {
   return {
+    hash,
+    query: "",
+    formattedQuery: "",
+    nudges: [],
+    tags: [],
+    tableReferences: [],
     optimization: { state },
-  } as OptimizedQuery;
+  } as unknown as OptimizedQuery;
 }
 
-describe("countUploadableQueries", () => {
-  test("counts improvements_available, no_improvement_found, and error", () => {
+describe("queryStats.analyzed source of truth", () => {
+  test("buildQueries().length counts exactly the queries reported to the site", () => {
     const results = [
-      fakeQuery("improvements_available"),
-      fakeQuery("no_improvement_found"),
-      fakeQuery("error"),
+      fakeQuery("a", "improvements_available"),
+      fakeQuery("b", "no_improvement_found"),
+      fakeQuery("c", "error"),
+      fakeQuery("d", "not_supported"),
+      fakeQuery("e", "timeout"),
+      fakeQuery("f", "waiting"),
+      fakeQuery("g", "optimizing"),
     ];
-    expect(countUploadableQueries(results)).toBe(3);
-  });
-
-  test("excludes not_supported, timeout, waiting, optimizing", () => {
-    const results = [
-      fakeQuery("not_supported"),
-      fakeQuery("timeout"),
-      fakeQuery("waiting"),
-      fakeQuery("optimizing"),
-    ];
-    expect(countUploadableQueries(results)).toBe(0);
-  });
-
-  test("counts only uploadable in a mixed set", () => {
-    const results = [
-      fakeQuery("improvements_available"),
-      fakeQuery("not_supported"),
-      fakeQuery("no_improvement_found"),
-      fakeQuery("timeout"),
-      fakeQuery("error"),
-      fakeQuery("waiting"),
-    ];
-    expect(countUploadableQueries(results)).toBe(3);
-  });
-});
-
-describe("UPLOADABLE_STATES matches buildQueries filter", () => {
-  test("buildQueries keeps exactly the same states as UPLOADABLE_STATES", () => {
-    const allStates = [
-      "improvements_available",
-      "no_improvement_found",
-      "error",
-      "not_supported",
-      "timeout",
-      "waiting",
-      "optimizing",
-    ];
-
-    for (const state of allStates) {
-      const results = [fakeQuery(state)];
-      const uploaded = buildQueries(results).length;
-      const counted = countUploadableQueries(results);
-      expect(counted, `state "${state}"`).toBe(uploaded);
-    }
+    expect(buildQueries(results).length).toBe(3);
   });
 });

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe } from "vitest";
+import { countUploadableQueries, UPLOADABLE_STATES } from "./runner.ts";
+import { buildQueries } from "./reporters/site-api.ts";
+import type { OptimizedQuery } from "./sql/recent-query.ts";
+
+function fakeQuery(state: string): OptimizedQuery {
+  return {
+    optimization: { state },
+  } as OptimizedQuery;
+}
+
+describe("countUploadableQueries", () => {
+  test("counts improvements_available, no_improvement_found, and error", () => {
+    const results = [
+      fakeQuery("improvements_available"),
+      fakeQuery("no_improvement_found"),
+      fakeQuery("error"),
+    ];
+    expect(countUploadableQueries(results)).toBe(3);
+  });
+
+  test("excludes not_supported, timeout, waiting, optimizing", () => {
+    const results = [
+      fakeQuery("not_supported"),
+      fakeQuery("timeout"),
+      fakeQuery("waiting"),
+      fakeQuery("optimizing"),
+    ];
+    expect(countUploadableQueries(results)).toBe(0);
+  });
+
+  test("counts only uploadable in a mixed set", () => {
+    const results = [
+      fakeQuery("improvements_available"),
+      fakeQuery("not_supported"),
+      fakeQuery("no_improvement_found"),
+      fakeQuery("timeout"),
+      fakeQuery("error"),
+      fakeQuery("waiting"),
+    ];
+    expect(countUploadableQueries(results)).toBe(3);
+  });
+});
+
+describe("UPLOADABLE_STATES matches buildQueries filter", () => {
+  test("buildQueries keeps exactly the same states as UPLOADABLE_STATES", () => {
+    const allStates = [
+      "improvements_available",
+      "no_improvement_found",
+      "error",
+      "not_supported",
+      "timeout",
+      "waiting",
+      "optimizing",
+    ];
+
+    for (const state of allStates) {
+      const results = [fakeQuery(state)];
+      const uploaded = buildQueries(results).length;
+      const counted = countUploadableQueries(results);
+      expect(counted, `state "${state}"`).toBe(uploaded);
+    }
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,6 +22,7 @@ import { QueryHash } from "./sql/recent-query.ts";
 import type { OptimizedQuery } from "./sql/recent-query.ts";
 import { ExportedStats } from "@query-doctor/core";
 import { readFile } from "node:fs/promises";
+import { buildQueries } from "./reporters/site-api.ts";
 
 export class Runner {
   constructor(
@@ -182,7 +183,7 @@ export class Runner {
       });
 
     console.log(
-      `Matched ${this.remote.optimizer.validQueriesProcessed} queries`,
+      `Matched ${this.remote.optimizer.validQueriesProcessed} unique queries out of ${recentQueries.length} log entries`,
     );
 
     const recommendations: ReportIndexRecommendation[] = [];
@@ -247,7 +248,7 @@ export class Runner {
       }
     }
 
-    const total = countUploadableQueries(allResults);
+    const analyzed = buildQueries(allResults, config).length;
 
     const statistics = deriveIndexStatistics(filteredRecommendations);
     const timeElapsed = Date.now() - startDate.getTime();
@@ -256,7 +257,7 @@ export class Runner {
       recommendations: filteredRecommendations,
       queriesPastThreshold: filteredThresholdWarnings,
       queryStats: Object.freeze({
-        total,
+        analyzed,
         matched: this.remote.optimizer.validQueriesProcessed,
         optimized: filteredRecommendations.length,
         errored: optimizedQueries.filter((q) => q.optimization.state === "error").length,
@@ -274,12 +275,6 @@ export class Runner {
     console.log(`Generating report (${reporter.provider()})`);
     await reporter.report(reportContext);
   }
-}
-
-export const UPLOADABLE_STATES = new Set(["improvements_available", "no_improvement_found", "error"]);
-
-export function countUploadableQueries(results: OptimizedQuery[]): number {
-  return results.filter((q) => UPLOADABLE_STATES.has(q.optimization.state)).length;
 }
 
 export type QueryProcessResult = OptimizedQuery;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -247,8 +247,7 @@ export class Runner {
       }
     }
 
-    const uploadableStates = new Set(["improvements_available", "no_improvement_found", "error"]);
-    const total = allResults.filter((q) => uploadableStates.has(q.optimization.state)).length;
+    const total = countUploadableQueries(allResults);
 
     const statistics = deriveIndexStatistics(filteredRecommendations);
     const timeElapsed = Date.now() - startDate.getTime();
@@ -275,6 +274,12 @@ export class Runner {
     console.log(`Generating report (${reporter.provider()})`);
     await reporter.report(reportContext);
   }
+}
+
+export const UPLOADABLE_STATES = new Set(["improvements_available", "no_improvement_found", "error"]);
+
+export function countUploadableQueries(results: OptimizedQuery[]): number {
+  return results.filter((q) => UPLOADABLE_STATES.has(q.optimization.state)).length;
 }
 
 export type QueryProcessResult = OptimizedQuery;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -114,8 +114,6 @@ export class Runner {
         error = err;
       });
 
-    let total = 0;
-
     console.time("total");
     const recentQueries: RecentQuery[] = [];
     for await (const chunk of stream) {
@@ -164,7 +162,6 @@ export class Runner {
         continue;
       }
 
-      total++;
       const recentQuery = await RecentQuery.fromLogEntry(query, hash);
       recentQueries.push(recentQuery)
     }
@@ -185,7 +182,7 @@ export class Runner {
       });
 
     console.log(
-      `Matched ${this.remote.optimizer.validQueriesProcessed} queries out of ${total}`,
+      `Matched ${this.remote.optimizer.validQueriesProcessed} queries`,
     );
 
     const recommendations: ReportIndexRecommendation[] = [];
@@ -249,6 +246,9 @@ export class Runner {
         );
       }
     }
+
+    const uploadableStates = new Set(["improvements_available", "no_improvement_found", "error"]);
+    const total = allResults.filter((q) => uploadableStates.has(q.optimization.state)).length;
 
     const statistics = deriveIndexStatistics(filteredRecommendations);
     const timeElapsed = Date.now() - startDate.getTime();


### PR DESCRIPTION
## Summary

The CI comment's "X queries analyzed" disagreed with the query list on the site — most dramatically on the [sin-bot PR 12 run](https://github.com/veksen/sin-bot/pull/12), which reported **4236 queries analyzed** in the PR comment while the site showed **74**.

Root cause: the reported count was computed at ingest time from the number of `plan:` log entries that passed filtering, not from the number of unique queries we actually analyze. The same 74 distinct queries ran ~57× each across 457 vitest specs, inflating the headline by ~57×.

This change:

- Computes `queryStats.analyzed` (renamed from `queryStats.total`) using `buildQueries(allResults, config).length` — the exact same list used to upload to the site, so the headline always matches what the user sees.
- Drops the separate `total` counter from the ingest loop.
- Drops the `countUploadableQueries` / `UPLOADABLE_STATES` helpers — they duplicated the filter that already lives in `buildQueries`.
- Restores the `Matched N unique queries out of M log entries` debug log by using `recentQueries.length` (no extra counter needed).
- Updates `ReportStatistics.total` → `ReportStatistics.analyzed` (docstring: "Number of unique queries analyzed and uploaded to the site"). Consumers updated in the success template and test fixtures.

## Why this is the right fix

Before deciding on the dedup approach, we added a diagnostic step to sin-bot's CI workflow that split the log by phase and counted `plan:` / `pg_catalog` / `information_schema` / `@qd_introspection` lines. Results on the sin-bot run:

| Phase                   | `plan:` entries | pg_catalog hits | info_schema hits | @qd_introspection |
| ----------------------- | --------------: | --------------: | ---------------: | ----------------: |
| `drizzle-kit migrate`   |              41 |              38 |                0 |                 0 |
| `npm test` (457 specs)  |            4220 |              95 |                0 |                 0 |

Key takeaways that shaped this PR:

1. **Migration phase is tiny.** 41 plan entries. The initial theory that drizzle-kit introspection was inflating the count does not hold.
2. **No `information_schema` traffic reaches `plan:` entries** in either phase.
3. **The 4220 test-phase entries are real application queries**, executed by the test suite. 457 specs × ~9 queries each ≈ 4100.
4. **The headline mismatch is purely about dedup**, not filtering. A pre-count `isSystemQuery` / `information_schema` filter would not have materially moved the number.

Given that, delegating to `buildQueries` is strictly better than any heuristic filter: there is one filter definition (in `site-api.ts`), and the CI comment is guaranteed to report whatever we actually uploaded.

## Test plan

- [x] `npx vitest run src/runner.test.ts src/reporters/github/github.test.ts` passes (20/20)
- [x] Existing template rendering tests updated for the `total` → `analyzed` rename
- [x] New `runner.test.ts` asserts `buildQueries(allResults).length` counts exactly the queries reported to the site on a mixed-state input
- [x] Re-run sin-bot PR 12 against this branch and confirm the PR comment reports 74 (or whatever the current analyzed count is) rather than a 4-digit number

## Follow-up (not in this PR)

- Consider surfacing the ingest-count elsewhere (e.g. in the Query Doctor run page) if users find the "executions vs. uniques" ratio useful for understanding test-suite shape.
- The diagnostic write-up lives at `.context/query-count-handoff.md` in this workspace and documents the ruled-out hypotheses so we don't retrace them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
