### PR TITLE
fix(sql): use AST-based statement type detection for isSelectQuery

### DIFF
--- a/src/sql/recent-query.test.ts
+++ b/src/sql/recent-query.test.ts
@@ -46,6 +46,30 @@ test("isSelectQuery returns false for non-SELECT statements", () => {
   ).toBe(false);
 });
 
+test("isSelectQuery returns false for DML containing SELECT subqueries", () => {
+  expect(
+    RecentQuery.isSelectQuery(
+      makeRawQuery({
+        query: 'UPDATE "public"."oban_jobs" SET "state" = $1 FROM (SELECT id FROM t) s WHERE id = s.id',
+      }),
+    ),
+  ).toBe(false);
+  expect(
+    RecentQuery.isSelectQuery(
+      makeRawQuery({
+        query: "INSERT INTO archive SELECT * FROM users",
+      }),
+    ),
+  ).toBe(false);
+  expect(
+    RecentQuery.isSelectQuery(
+      makeRawQuery({
+        query: "DELETE FROM users WHERE EXISTS (SELECT 1 FROM banned)",
+      }),
+    ),
+  ).toBe(false);
+});
+
 // --- isSystemQuery ---
 
 test("isSystemQuery returns true for pg_ tables", () => {
@@ -192,4 +216,46 @@ test("analyze throws on unparseable SQL", async () => {
   await expect(
     RecentQuery.analyze(data, testHash, 3000),
   ).rejects.toThrow();
+});
+
+// --- statementType-based isSelectQuery via analyze ---
+
+test("analyze sets isSelectQuery=true for SELECT", async () => {
+  const data = makeRawQuery({ query: "SELECT * FROM users" });
+  const rq = await RecentQuery.analyze(data, testHash, 1000);
+  expect(rq.isSelectQuery).toBe(true);
+});
+
+test("analyze sets isSelectQuery=true for CTE with SELECT", async () => {
+  const data = makeRawQuery({
+    query: "WITH cte AS (SELECT id FROM users) SELECT * FROM cte",
+  });
+  const rq = await RecentQuery.analyze(data, testHash, 1000);
+  expect(rq.isSelectQuery).toBe(true);
+});
+
+test("analyze sets isSelectQuery=false for UPDATE even with SELECT subquery", async () => {
+  const data = makeRawQuery({
+    query:
+      'UPDATE "public"."jobs" SET "state" = $1 FROM (SELECT id FROM "public"."jobs" WHERE state = $2 LIMIT 10) AS s1 WHERE "jobs".id = s1.id',
+  });
+  const rq = await RecentQuery.analyze(data, testHash, 1000);
+  expect(rq.isSelectQuery).toBe(false);
+});
+
+test("analyze sets isSelectQuery=false for INSERT ... SELECT", async () => {
+  const data = makeRawQuery({
+    query: "INSERT INTO archive SELECT * FROM users WHERE active = false",
+  });
+  const rq = await RecentQuery.analyze(data, testHash, 1000);
+  expect(rq.isSelectQuery).toBe(false);
+});
+
+test("analyze sets isSelectQuery=false for DELETE with EXISTS subquery", async () => {
+  const data = makeRawQuery({
+    query:
+      "DELETE FROM users WHERE EXISTS (SELECT 1 FROM banned WHERE banned.user_id = users.id)",
+  });
+  const rq = await RecentQuery.analyze(data, testHash, 1000);
+  expect(rq.isSelectQuery).toBe(false);
 });

--- a/src/sql/recent-query.ts
+++ b/src/sql/recent-query.ts
@@ -8,6 +8,7 @@ import {
   PostgresQueryBuilder,
   PssRewriter,
   SQLCommenterTag,
+  type StatementType,
   type TableReference,
 } from "@query-doctor/core";
 import { parse } from "@libpg-query/parser";
@@ -46,6 +47,7 @@ export class RecentQuery {
     readonly hash: QueryHash,
     readonly seenAt: number,
     analysisSkipped = false,
+    statementType?: StatementType,
   ) {
     this.username = data.username;
     this.query = data.query;
@@ -57,7 +59,9 @@ export class RecentQuery {
     this.analysisSkipped = analysisSkipped;
 
     this.isSystemQuery = RecentQuery.isSystemQuery(tableReferences);
-    this.isSelectQuery = RecentQuery.isSelectQuery(data);
+    this.isSelectQuery = statementType !== undefined
+      ? statementType === "select"
+      : RecentQuery.isSelectQuery(data);
     this.isIntrospection = RecentQuery.isIntrospection(data);
     this.isTargetlessSelectQuery = this.isSelectQuery
       ? RecentQuery.isTargetlessSelectQuery(tableReferences)
@@ -123,6 +127,8 @@ export class RecentQuery {
       analysis.nudges,
       hash,
       seenAt,
+      false,
+      analysis.statementType,
     );
   }
 
@@ -147,7 +153,7 @@ export class RecentQuery {
   }
 
   static isSelectQuery(data: RawRecentQuery): boolean {
-    return /select/i.test(data.query);
+    return /^\s*select/i.test(data.query);
   }
 
   static isSystemQuery(referencedTables: TableReference[]): boolean {


### PR DESCRIPTION
## Summary

- Uses `analysis.statementType` from `@query-doctor/core` (AST-based) to determine `isSelectQuery` instead of the regex `/select/i`
- The unanchored regex matched `SELECT` anywhere in the query, misclassifying UPDATE/INSERT/DELETE queries that contain SELECT subqueries (e.g. `UPDATE ... FROM (SELECT ...)`)
- Falls back to an anchored regex `^\s*select` for skipped queries (>50KB) where analysis is not available
- Adds 6 new tests covering DML with SELECT subqueries and `analyze()`-based detection

## Dependencies

Requires `@query-doctor/core` >= 0.8.1 which adds `statementType: StatementType` to `AnalysisResult`. Companion PR: Query-Doctor/Site#2710.

## Why the regex existed

CTE queries like `WITH cte AS (...) SELECT ...` start with `WITH`, not `SELECT`. The non-anchored regex was likely intended to catch those. The AST-based approach handles CTEs correctly because the parser identifies the outermost statement type (`SelectStmt` for `WITH ... SELECT`, `UpdateStmt` for `WITH ... UPDATE`).

## Test plan

- [ ] Existing `isSelectQuery` tests still pass (SELECT, INSERT, UPDATE, DELETE)
- [ ] New tests verify DML with SELECT subqueries are correctly classified as non-SELECT
- [ ] New `analyze()` integration tests verify AST-based detection for CTE, UPDATE+subquery, INSERT...SELECT, DELETE+EXISTS
- [ ] Compat CI should pass once paired with the core PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)