### PR TITLE
fix: return latest schema from getStatus instead of stale sync snapshot

### DIFF
--- a/src/remote/remote-controller.ts
+++ b/src/remote/remote-controller.ts
@@ -89,9 +89,17 @@ export class RemoteController {
     if (!this.syncResponse) {
       return { status: this.syncStatus };
     }
-    const { schema, meta } = this.syncResponse;
+    const { schema: initialSchema, meta } = this.syncResponse;
     const { queries, diffs, disabledIndexes, pgStatStatementsNotInstalled } =
       await this.remote.getStatus();
+
+    // After the poll above, SchemaLoader has the latest schema from the
+    // source DB. Use it instead of the potentially stale initial sync
+    // schema, so newly created tables are reflected immediately.
+    const latestSchema = this.remote.getLatestSchema();
+    const schema = latestSchema
+      ? { type: "ok" as const, value: latestSchema }
+      : initialSchema;
 
     let deltas: DeltasResult;
     if (diffs.status === "fulfilled") {

--- a/src/remote/remote.test.ts
+++ b/src/remote/remote.test.ts
@@ -2,6 +2,7 @@ import { test, expect, vi, afterEach } from "vitest";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
 import { Connectable } from "../sync/connectable.ts";
 import { Remote } from "./remote.ts";
+import { RemoteController } from "./remote-controller.ts";
 import { Pool } from "pg";
 
 import { ConnectionManager } from "../sync/connection-manager.ts";
@@ -427,6 +428,186 @@ test("schema loader detects changes after database modification", async () => {
         typeof diff.path === "string" && diff.path.includes("indexes")
       );
       expect(addedIndexDiff?.op, "Should detect index addition").toEqual("add");
+
+      await sourcePg.end();
+    } finally {
+      await Promise.all([sourceDb.stop(), targetDb.stop()]);
+    }
+});
+
+type StatusResult = {
+  status: string;
+  schema: { type: string; value: { tables: { tableName: { toString(): string } }[] } };
+  deltas: { type: string; value: unknown[] } | { type: string; value: string };
+};
+
+type DeltaOp = {
+  op: string;
+  path: string;
+  value?: { type?: string; tableName?: string };
+};
+
+function getTableNames(status: StatusResult): string[] {
+  return status.schema.value.tables.map((t) => t.tableName.toString());
+}
+
+function getDeltaOps(status: StatusResult): DeltaOp[] {
+  if (status.deltas.type !== "ok") {
+    throw new Error(`Expected deltas type "ok", got "${status.deltas.type}"`);
+  }
+  return status.deltas.value as DeltaOp[];
+}
+
+function getTableAddOps(deltas: DeltaOp[]): DeltaOp[] {
+  return deltas.filter((d) => d.op === "add" && d.path.startsWith("/tables/"));
+}
+
+function getAddedTableNames(deltas: DeltaOp[]): string[] {
+  return getTableAddOps(deltas)
+    .map((d) => String(d.value?.tableName))
+    .filter((name) => name !== "undefined");
+}
+
+test("getStatus returns latest schema after tables are added post-sync", async () => {
+    const [sourceDb, targetDb] = await Promise.all([
+      new PostgreSqlContainer("postgres:17")
+        .withCopyContentToContainer([
+          {
+            content: `
+              create extension pg_stat_statements;
+              create table initial_table(id int);
+            `,
+            target: "/docker-entrypoint-initdb.d/init.sql",
+          },
+        ])
+        .withCommand(["-c", "shared_preload_libraries=pg_stat_statements"])
+        .start(),
+      testSpawnTarget(),
+    ]);
+
+    try {
+      const target = Connectable.fromString(targetDb.getConnectionUri());
+      const source = Connectable.fromString(sourceDb.getConnectionUri());
+
+      const manager = ConnectionManager.forLocalDatabase();
+      await using remote = new Remote(target, manager);
+      const controller = new RemoteController(remote);
+
+      // Initial sync captures only initial_table
+      await controller.onFullSync(source);
+
+      const sourcePg = new Pool({ connectionString: source.toString() });
+
+      // Add many tables after the initial sync
+      const createStatements = Array.from(
+        { length: 50 },
+        (_, i) => `create table new_table_${i}(id int);`,
+      ).join("\n");
+      await sourcePg.query(createStatements);
+
+      // getStatus() triggers a poll which should refresh the schema
+      const status = await controller.getStatus() as StatusResult;
+
+      expect(status.schema.type).toEqual("ok");
+
+      const tableNames = getTableNames(status);
+
+      // Should contain both the original table and all new tables
+      expect(tableNames).toContain("initial_table");
+      for (let i = 0; i < 50; i++) {
+        expect(tableNames, `Should contain new_table_${i}`).toContain(`new_table_${i}`);
+      }
+
+      // onFullSync() internally calls remote.getStatus() which triggers
+      // the first poll and establishes the SchemaLoader baseline. So this
+      // second poll detects the 50 new tables as deltas.
+      const deltas = getDeltaOps(status);
+      const addedNames = getAddedTableNames(deltas);
+      expect(addedNames.length, "Should have 50 table-add deltas").toEqual(50);
+      for (let i = 0; i < 50; i++) {
+        expect(addedNames, `Deltas should include new_table_${i}`).toContain(`new_table_${i}`);
+      }
+      // Every delta should be an "add" op on /tables/*
+      expect(getTableAddOps(deltas).length).toEqual(deltas.length);
+
+      await sourcePg.end();
+    } finally {
+      await Promise.all([sourceDb.stop(), targetDb.stop()]);
+    }
+});
+
+test("schema and deltas stay consistent across multiple polls", async () => {
+    const [sourceDb, targetDb] = await Promise.all([
+      new PostgreSqlContainer("postgres:17")
+        .withCopyContentToContainer([
+          {
+            content: `
+              create extension pg_stat_statements;
+              create table original(id int);
+            `,
+            target: "/docker-entrypoint-initdb.d/init.sql",
+          },
+        ])
+        .withCommand(["-c", "shared_preload_libraries=pg_stat_statements"])
+        .start(),
+      testSpawnTarget(),
+    ]);
+
+    try {
+      const target = Connectable.fromString(targetDb.getConnectionUri());
+      const source = Connectable.fromString(sourceDb.getConnectionUri());
+
+      const manager = ConnectionManager.forLocalDatabase();
+      await using remote = new Remote(target, manager);
+      const controller = new RemoteController(remote);
+      const sourcePg = new Pool({ connectionString: source.toString() });
+
+      await controller.onFullSync(source);
+
+      // --- Poll 1: no source changes since onFullSync's internal poll, deltas empty ---
+      const status1 = await controller.getStatus() as StatusResult;
+      expect(status1.schema.type).toEqual("ok");
+      expect(getTableNames(status1)).toContain("original");
+      expect(getDeltaOps(status1), "No changes since sync: deltas should be empty").toEqual([]);
+
+      // --- Add a table ---
+      await sourcePg.query("create table added_first(id int);");
+
+      // --- Poll 2: schema includes new table, deltas show exactly what was added ---
+      const status2 = await controller.getStatus() as StatusResult;
+      expect(status2.schema.type).toEqual("ok");
+      const names2 = getTableNames(status2);
+      expect(names2).toContain("original");
+      expect(names2).toContain("added_first");
+      const deltas2 = getDeltaOps(status2);
+      const added2 = getAddedTableNames(deltas2);
+      expect(added2, "Delta should contain exactly the added table").toEqual(["added_first"]);
+      // No other ops besides the table add
+      expect(getTableAddOps(deltas2).length).toEqual(deltas2.length);
+
+      // --- Poll 3: no changes, deltas empty, schema unchanged ---
+      const status3 = await controller.getStatus() as StatusResult;
+      expect(status3.schema.type).toEqual("ok");
+      const names3 = getTableNames(status3);
+      expect(names3).toContain("original");
+      expect(names3).toContain("added_first");
+      expect(names3).toHaveLength(names2.length);
+      expect(getDeltaOps(status3), "No changes since last poll: deltas should be empty").toEqual([]);
+
+      // --- Add another table ---
+      await sourcePg.query("create table added_second(id int);");
+
+      // --- Poll 4: deltas show only the second table, not the first ---
+      const status4 = await controller.getStatus() as StatusResult;
+      expect(status4.schema.type).toEqual("ok");
+      const names4 = getTableNames(status4);
+      expect(names4).toContain("original");
+      expect(names4).toContain("added_first");
+      expect(names4).toContain("added_second");
+      const deltas4 = getDeltaOps(status4);
+      const added4 = getAddedTableNames(deltas4);
+      expect(added4, "Delta should contain only the second added table").toEqual(["added_second"]);
+      expect(getTableAddOps(deltas4).length).toEqual(deltas4.length);
 
       await sourcePg.end();
     } finally {

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -178,6 +178,10 @@ export class Remote extends EventEmitter<RemoteEvents> {
     };
   }
 
+  getLatestSchema(): FullSchema | undefined {
+    return this.schemaLoader?.getLatestSchema();
+  }
+
   async getStatus() {
     const queries = this.optimizer.getQueries();
     const disabledIndexes = this.optimizer.getDisabledIndexes();

--- a/src/remote/schema-loader.ts
+++ b/src/remote/schema-loader.ts
@@ -9,6 +9,11 @@ export class SchemaLoader {
   ) {}
 
   private readonly differ = new SchemaDiffer();
+  private latestSchema?: FullSchema;
+
+  getLatestSchema(): FullSchema | undefined {
+    return this.latestSchema;
+  }
 
   async poll() {
     const connector = this.sourceManager.getConnectorFor(this.connectable);
@@ -19,6 +24,7 @@ export class SchemaLoader {
   }
 
   update(fullSchema: FullSchema) {
+    this.latestSchema = fullSchema;
     return this.differ.put(this.connectable, fullSchema);
   }
 }

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -183,6 +183,12 @@ export async function createServer(
         const result = await remoteController.onFullSync(body.data.db);
         return reply.status(result.status).send(result.body);
       });
+    } else {
+      fastify.post("/postgres", async (_request, reply) => {
+        log.info(`[POST] /postgres (re-sync from SOURCE_DATABASE_URL)`, "http");
+        const result = await remoteController.onFullSync(sourceDb);
+        return reply.status(result.status).send(result.body);
+      });
     }
 
     fastify.get("/postgres", async (request, reply) => {


### PR DESCRIPTION
## Summary

- `getStatus()` now returns the latest schema from SchemaLoader (refreshed each poll) instead of the stale schema captured during initial sync, fixing #2727 where schema introspection silently truncated for large databases
- Registers `POST /postgres` in /connect mode so users can trigger a manual re-sync when `SOURCE_DATABASE_URL` is set
- Adds integration tests verifying both schema freshness and delta consistency across multiple polls

## Test plan

- [x] Existing tests pass (10/10)
- [x] New test: `getStatus returns latest schema after tables are added post-sync` — syncs with 1 table, adds 50 post-sync, verifies all 51 in schema and deltas correctly report 50 additions
- [x] New test: `schema and deltas stay consistent across multiple polls` — 4-poll lifecycle verifying schema updates, delta accuracy (correct table names), and delta reset between polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)