### PR TITLE
fix: distinguish missing baseline from Site API fetch error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,19 +74,27 @@ async function runInCI(
   if (siteApiEndpoint && repo) {
     const comparisonBranch =
       config.comparisonBranch ?? process.env.GITHUB_BASE_REF ?? branch;
-    previousRun = await fetchPreviousRun(
+    const result = await fetchPreviousRun(
       siteApiEndpoint,
       repo,
       comparisonBranch,
       runId ?? undefined,
     );
     reportContext.comparisonBranch = comparisonBranch;
-    if (!previousRun) {
+    if (result.kind === "found") {
+      previousRun = result.run;
+    } else if (result.kind === "not-found") {
       log.info(
         "main",
         `No baseline found on branch "${comparisonBranch}". Comparison will be skipped. ` +
         `To establish a baseline, run the analyzer on pushes to "${comparisonBranch}" ` +
         `(add "push: branches: [${comparisonBranch}]" to your workflow trigger).`,
+      );
+    } else {
+      log.warn(
+        "main",
+        `Failed to fetch baseline for branch "${comparisonBranch}" (${result.reason}). ` +
+        `Comparison will be skipped. This is likely a transient Site API issue — re-run the check to retry.`,
       );
     }
   }

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -276,12 +276,17 @@ export async function postToSiteApi(
   }
 }
 
+export type PreviousRunResult =
+  | { kind: "found"; run: PreviousRun }
+  | { kind: "not-found" }
+  | { kind: "error"; reason: string };
+
 export async function fetchPreviousRun(
   endpoint: string,
   repo: string,
   branch?: string,
   excludeId?: string,
-): Promise<PreviousRun | null> {
+): Promise<PreviousRunResult> {
   const params = new URLSearchParams({ repo });
   if (branch) params.set("branch", branch);
   if (excludeId) params.set("excludeId", excludeId);
@@ -294,15 +299,15 @@ export async function fetchPreviousRun(
     });
     if (response.status === 404) {
       console.log("No previous run found");
-      return null;
+      return { kind: "not-found" };
     }
     if (!response.ok) {
       console.warn(`Failed to fetch previous run: ${response.status}`);
-      return null;
+      return { kind: "error", reason: `HTTP ${response.status}` };
     }
-    return (await response.json()) as PreviousRun;
+    return { kind: "found", run: (await response.json()) as PreviousRun };
   } catch (err) {
     console.warn(`Failed to fetch previous run: ${err}`);
-    return null;
+    return { kind: "error", reason: `${err}` };
   }
 }


### PR DESCRIPTION
## Summary

- `fetchPreviousRun` now returns a `PreviousRunResult` discriminated union (`found` / `not-found` / `error`) so callers can tell a genuine 404 ("no baseline on branch") apart from a 5xx, timeout, or network failure.
- `main.ts` emits the existing "No baseline found... add a push trigger" guidance only on `not-found`, and a new warning with the actual reason on `error` ("Failed to fetch baseline... likely a transient Site API issue — re-run the check to retry.").
- Previously both cases produced the same misleading "No baseline found" log, so a 502 from the Site API looked identical to an actually-missing baseline.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 161/161 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)