### PR TITLE
fix: pair (schema, table) as composite in getTotalRowCount

### DIFF
--- a/src/sync/pg-connector.test.ts
+++ b/src/sync/pg-connector.test.ts
@@ -223,3 +223,100 @@ test("getTotalRowCount does not count tables outside the requested set", async (
   }
 });
 
+// Guards against a cartesian re-implementation of the fix, e.g.
+//   n.nspname = ANY($1) AND c.relname = ANY($2)
+// With (public.x, public.y, reporting.x, reporting.y) all present and only
+// (public.x, reporting.y) requested, the cartesian form would wrongly count
+// public.y and reporting.x because both schemas are in $1 and both names are
+// in $2. Composite-pair matching must check the (schema, name) pair, not the
+// cross-product of the two arrays.
+test("getTotalRowCount matches composite (schema, table) pairs, not the cross-product", async () => {
+  const pg = await new PostgreSqlContainer("postgres:17")
+    .withCopyContentToContainer([
+      {
+        content: `
+          CREATE SCHEMA reporting;
+
+          CREATE TABLE public.x(id int);
+          INSERT INTO public.x SELECT generate_series(1, 100);
+
+          CREATE TABLE public.y(id int);
+          INSERT INTO public.y SELECT generate_series(1, 50000);
+
+          CREATE TABLE reporting.x(id int);
+          INSERT INTO reporting.x SELECT generate_series(1, 80000);
+
+          CREATE TABLE reporting.y(id int);
+          INSERT INTO reporting.y SELECT generate_series(1, 200);
+
+          ANALYZE public.x;
+          ANALYZE public.y;
+          ANALYZE reporting.x;
+          ANALYZE reporting.y;
+        `,
+        target: "/docker-entrypoint-initdb.d/init.sql",
+      },
+    ])
+    .start();
+
+  const manager = ConnectionManager.forLocalDatabase();
+  const conn = Connectable.fromString(pg.getConnectionUri());
+  const connector = manager.getConnectorFor(conn);
+
+  try {
+    const tables = [
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("x") },
+      { schemaName: PgIdentifier.fromString("reporting"), tableName: PgIdentifier.fromString("y") },
+    ];
+
+    const total = await connector.getTotalRowCount(tables);
+
+    // Correct total: 100 + 200 = 300. Cartesian would also count public.y
+    // (50000) and reporting.x (80000). < 1000 cleanly rejects the cartesian
+    // shape, which could not produce a value this small given the non-requested
+    // tables.
+    expect(total).toBeLessThan(1000);
+  } finally {
+    await manager.closeAll();
+    await pg.stop();
+  }
+});
+
+// Guards against a re-implementation that swaps ANY(set) for a JOIN. A JOIN
+// against an unnest'd set of duplicates multiplies each catalog row by the
+// number of matching input pairs, double-counting reltuples. ANY(set) is a
+// boolean predicate and should count each pg_class row at most once.
+test("getTotalRowCount does not double-count when a table appears twice in the input", async () => {
+  const pg = await new PostgreSqlContainer("postgres:17")
+    .withCopyContentToContainer([
+      {
+        content: `
+          CREATE TABLE t(id int);
+          INSERT INTO t SELECT generate_series(1, 5000);
+
+          ANALYZE t;
+        `,
+        target: "/docker-entrypoint-initdb.d/init.sql",
+      },
+    ])
+    .start();
+
+  const manager = ConnectionManager.forLocalDatabase();
+  const conn = Connectable.fromString(pg.getConnectionUri());
+  const connector = manager.getConnectorFor(conn);
+
+  try {
+    const pair = {
+      schemaName: PgIdentifier.fromString("public"),
+      tableName: PgIdentifier.fromString("t"),
+    };
+
+    const total = await connector.getTotalRowCount([pair, pair]);
+
+    expect(total).toBeGreaterThanOrEqual(5000);
+    expect(total).toBeLessThan(10000);
+  } finally {
+    await manager.closeAll();
+    await pg.stop();
+  }
+});

--- a/src/sync/pg-connector.test.ts
+++ b/src/sync/pg-connector.test.ts
@@ -134,21 +134,29 @@ test("getTotalRowCount sums reltuples across all tables in a single schema", asy
   }
 });
 
-test("getTotalRowCount sums reltuples across multiple schemas", async () => {
+// When requested tables span multiple schemas with uneven counts per schema,
+// the pre-fix dedup would shrink schemaNames below tableNames, pairing
+// (schema[i], table[i]) by position and NULL-padding the tail — dropping
+// tables past the shorter array.
+test("getTotalRowCount sums reltuples with uneven table counts across schemas", async () => {
   const pg = await new PostgreSqlContainer("postgres:17")
     .withCopyContentToContainer([
       {
         content: `
           CREATE SCHEMA reporting;
 
-          CREATE TABLE public.orders(id int);
-          INSERT INTO public.orders SELECT generate_series(1, 50000);
+          CREATE TABLE public.a(id int);
+          INSERT INTO public.a SELECT generate_series(1, 1000);
 
-          CREATE TABLE reporting.events(id int);
-          INSERT INTO reporting.events SELECT generate_series(1, 80000);
+          CREATE TABLE public.b(id int);
+          INSERT INTO public.b SELECT generate_series(1, 2000);
 
-          ANALYZE public.orders;
-          ANALYZE reporting.events;
+          CREATE TABLE reporting.c(id int);
+          INSERT INTO reporting.c SELECT generate_series(1, 4000);
+
+          ANALYZE public.a;
+          ANALYZE public.b;
+          ANALYZE reporting.c;
         `,
         target: "/docker-entrypoint-initdb.d/init.sql",
       },
@@ -161,13 +169,16 @@ test("getTotalRowCount sums reltuples across multiple schemas", async () => {
 
   try {
     const tables = [
-      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("orders") },
-      { schemaName: PgIdentifier.fromString("reporting"), tableName: PgIdentifier.fromString("events") },
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("a") },
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("b") },
+      { schemaName: PgIdentifier.fromString("reporting"), tableName: PgIdentifier.fromString("c") },
     ];
 
     const total = await connector.getTotalRowCount(tables);
 
-    expect(total).toBeGreaterThanOrEqual(130_000);
+    // All three must contribute: sum of any pair is at most 6000 (b+c),
+    // so > 6000 proves no table was dropped.
+    expect(total).toBeGreaterThan(6000);
   } finally {
     await manager.closeAll();
     await pg.stop();
@@ -212,17 +223,3 @@ test("getTotalRowCount does not count tables outside the requested set", async (
   }
 });
 
-test("getTotalRowCount returns 0 for empty table list without querying", async () => {
-  const pg = await new PostgreSqlContainer("postgres:17").start();
-  const manager = ConnectionManager.forLocalDatabase();
-  const conn = Connectable.fromString(pg.getConnectionUri());
-  const connector = manager.getConnectorFor(conn);
-
-  try {
-    const total = await connector.getTotalRowCount([]);
-    expect(total).toEqual(0);
-  } finally {
-    await manager.closeAll();
-    await pg.stop();
-  }
-});

--- a/src/sync/pg-connector.test.ts
+++ b/src/sync/pg-connector.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "vitest";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
 import { ConnectionManager } from "./connection-manager.ts";
 import { Connectable } from "./connectable.ts";
+import { PgIdentifier } from "@query-doctor/core";
 
 test("getRecentQueries resolves pg_stat_statements in a non-default schema", async () => {
     const pg = await new PostgreSqlContainer("postgres:17")
@@ -93,4 +94,135 @@ test("resetPgStatStatements works with a non-default schema", async () => {
       await manager.closeAll();
       await pg.stop();
     }
+});
+
+test("getTotalRowCount sums reltuples across all tables in a single schema", async () => {
+  const pg = await new PostgreSqlContainer("postgres:17")
+    .withCopyContentToContainer([
+      {
+        content: `
+          CREATE TABLE small_audit(id int);
+          INSERT INTO small_audit SELECT generate_series(1, 77);
+
+          CREATE TABLE big_users(id int);
+          INSERT INTO big_users SELECT generate_series(1, 300000);
+
+          ANALYZE small_audit;
+          ANALYZE big_users;
+        `,
+        target: "/docker-entrypoint-initdb.d/init.sql",
+      },
+    ])
+    .start();
+
+  const manager = ConnectionManager.forLocalDatabase();
+  const conn = Connectable.fromString(pg.getConnectionUri());
+  const connector = manager.getConnectorFor(conn);
+
+  try {
+    const tables = [
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("small_audit") },
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("big_users") },
+    ];
+
+    const total = await connector.getTotalRowCount(tables);
+
+    expect(total).toBeGreaterThanOrEqual(300_000);
+  } finally {
+    await manager.closeAll();
+    await pg.stop();
+  }
+});
+
+test("getTotalRowCount sums reltuples across multiple schemas", async () => {
+  const pg = await new PostgreSqlContainer("postgres:17")
+    .withCopyContentToContainer([
+      {
+        content: `
+          CREATE SCHEMA reporting;
+
+          CREATE TABLE public.orders(id int);
+          INSERT INTO public.orders SELECT generate_series(1, 50000);
+
+          CREATE TABLE reporting.events(id int);
+          INSERT INTO reporting.events SELECT generate_series(1, 80000);
+
+          ANALYZE public.orders;
+          ANALYZE reporting.events;
+        `,
+        target: "/docker-entrypoint-initdb.d/init.sql",
+      },
+    ])
+    .start();
+
+  const manager = ConnectionManager.forLocalDatabase();
+  const conn = Connectable.fromString(pg.getConnectionUri());
+  const connector = manager.getConnectorFor(conn);
+
+  try {
+    const tables = [
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("orders") },
+      { schemaName: PgIdentifier.fromString("reporting"), tableName: PgIdentifier.fromString("events") },
+    ];
+
+    const total = await connector.getTotalRowCount(tables);
+
+    expect(total).toBeGreaterThanOrEqual(130_000);
+  } finally {
+    await manager.closeAll();
+    await pg.stop();
+  }
+});
+
+test("getTotalRowCount does not count tables outside the requested set", async () => {
+  const pg = await new PostgreSqlContainer("postgres:17")
+    .withCopyContentToContainer([
+      {
+        content: `
+          CREATE TABLE wanted(id int);
+          INSERT INTO wanted SELECT generate_series(1, 1000);
+
+          CREATE TABLE unwanted(id int);
+          INSERT INTO unwanted SELECT generate_series(1, 500000);
+
+          ANALYZE wanted;
+          ANALYZE unwanted;
+        `,
+        target: "/docker-entrypoint-initdb.d/init.sql",
+      },
+    ])
+    .start();
+
+  const manager = ConnectionManager.forLocalDatabase();
+  const conn = Connectable.fromString(pg.getConnectionUri());
+  const connector = manager.getConnectorFor(conn);
+
+  try {
+    const tables = [
+      { schemaName: PgIdentifier.fromString("public"), tableName: PgIdentifier.fromString("wanted") },
+    ];
+
+    const total = await connector.getTotalRowCount(tables);
+
+    expect(total).toBeGreaterThanOrEqual(1000);
+    expect(total).toBeLessThan(500_000);
+  } finally {
+    await manager.closeAll();
+    await pg.stop();
+  }
+});
+
+test("getTotalRowCount returns 0 for empty table list without querying", async () => {
+  const pg = await new PostgreSqlContainer("postgres:17").start();
+  const manager = ConnectionManager.forLocalDatabase();
+  const conn = Connectable.fromString(pg.getConnectionUri());
+  const connector = manager.getConnectorFor(conn);
+
+  try {
+    const total = await connector.getTotalRowCount([]);
+    expect(total).toEqual(0);
+  } finally {
+    await manager.closeAll();
+    await pg.stop();
+  }
 });

--- a/src/sync/pg-connector.test.ts
+++ b/src/sync/pg-connector.test.ts
@@ -127,7 +127,7 @@ test("getTotalRowCount sums reltuples across all tables in a single schema", asy
 
     const total = await connector.getTotalRowCount(tables);
 
-    expect(total).toBeGreaterThanOrEqual(300_000);
+    expect(total).toBe(77 + 300_000);
   } finally {
     await manager.closeAll();
     await pg.stop();
@@ -176,9 +176,7 @@ test("getTotalRowCount sums reltuples with uneven table counts across schemas", 
 
     const total = await connector.getTotalRowCount(tables);
 
-    // All three must contribute: sum of any pair is at most 6000 (b+c),
-    // so > 6000 proves no table was dropped.
-    expect(total).toBeGreaterThan(6000);
+    expect(total).toBe(1000 + 2000 + 4000);
   } finally {
     await manager.closeAll();
     await pg.stop();
@@ -215,8 +213,7 @@ test("getTotalRowCount does not count tables outside the requested set", async (
 
     const total = await connector.getTotalRowCount(tables);
 
-    expect(total).toBeGreaterThanOrEqual(1000);
-    expect(total).toBeLessThan(500_000);
+    expect(total).toBe(1000);
   } finally {
     await manager.closeAll();
     await pg.stop();
@@ -271,11 +268,7 @@ test("getTotalRowCount matches composite (schema, table) pairs, not the cross-pr
 
     const total = await connector.getTotalRowCount(tables);
 
-    // Correct total: 100 + 200 = 300. Cartesian would also count public.y
-    // (50000) and reporting.x (80000). < 1000 cleanly rejects the cartesian
-    // shape, which could not produce a value this small given the non-requested
-    // tables.
-    expect(total).toBeLessThan(1000);
+    expect(total).toBe(100 + 200);
   } finally {
     await manager.closeAll();
     await pg.stop();
@@ -313,8 +306,7 @@ test("getTotalRowCount does not double-count when a table appears twice in the i
 
     const total = await connector.getTotalRowCount([pair, pair]);
 
-    expect(total).toBeGreaterThanOrEqual(5000);
-    expect(total).toBeLessThan(10000);
+    expect(total).toBe(5000);
   } finally {
     await manager.closeAll();
     await pg.stop();

--- a/src/sync/pg-connector.ts
+++ b/src/sync/pg-connector.ts
@@ -429,20 +429,17 @@ ORDER BY
   ): Promise<number> {
     if (tables.length === 0) return 0;
 
-    const schemaNames = Array.from(
-      new Set(tables.map((t) => t.schemaName.toString())),
-    );
-    const tableNames = Array.from(
-      new Set(tables.map((t) => t.tableName.toString())),
-    );
+    const schemaNames = tables.map((t) => t.schemaName.toString());
+    const tableNames = tables.map((t) => t.tableName.toString());
 
     const results = await this.db.exec<{ total_rows: string }>(
       `SELECT COALESCE(SUM(c.reltuples), 0)::bigint as total_rows
        FROM pg_class c
        JOIN pg_namespace n ON n.oid = c.relnamespace
-       JOIN unnest($1::text[], $2::text[]) AS t(schema_name, table_name)
-         ON n.nspname = t.schema_name AND c.relname = t.table_name
-       WHERE c.relkind IN ('r', 'm')`,
+       WHERE c.relkind IN ('r', 'm')
+         AND (n.nspname, c.relname) = ANY(
+           SELECT s, t FROM unnest($1::text[], $2::text[]) AS x(s, t)
+         )`,
       [schemaNames, tableNames],
     );
     return Number(results[0]?.total_rows ?? 0);


### PR DESCRIPTION
## Summary

- `getTotalRowCount` deduplicated schemas and tables into separate arrays and paired them positionally via `unnest($1, $2)`. For the common case of one schema with N tables, Postgres padded the shorter schema array with NULL, dropping every table past the first from the JOIN — so `SUM(reltuples)` came from a single table.
- In production this caused a 300K-row table to report as 77 rows (the first table in the list was a small audit table), pushing `decideStatsStrategy` through the 10k-row default instead of `dumpSourceStats` and silently degrading optimization for the whole source.
- Fix: match composite `(nspname, relname)` pairs from position-aligned non-deduplicated arrays via `= ANY(SELECT s, t FROM unnest(...))`, so every requested table contributes exactly once.

## Test plan

Five testcontainer integration tests in `src/sync/pg-connector.test.ts`, each guarding a specific incorrect implementation shape. Every test asserts the exact expected sum (`toBe(...)`) — `reltuples` after `ANALYZE` on uniformly-inserted rows is exact at these sizes (all tables below the sampling threshold).

- [x] **single schema, multi-table** — direct repro of the Slack bug. Verified to fail on pre-fix code with `expected 77 to be 300077`.
- [x] **uneven table counts across schemas** — 3 tables (1K/2K/4K) across 2 schemas, where the pre-fix dedup shrinks `schemaNames` below `tableNames` and NULL-pads the tail. Verified to fail on pre-fix code with `expected 1000 to be 7000`.
- [x] **request-set scoping** — a 500K `unwanted` table in the same schema must not leak into the sum.
- [x] **composite pair vs. cross-product** — guards against a cartesian re-implementation (`n.nspname = ANY($1) AND c.relname = ANY($2)`). With `public.{x,y}` and `reporting.{x,y}` all present but only `(public.x, reporting.y)` requested, a cartesian impl would wrongly count `public.y` and `reporting.x`. Verified: cartesian variant yields 130300 instead of 300.
- [x] **duplicate input** — passing the same `(schema, table)` pair twice must not double-count. Guards against a `JOIN unnest(...)` re-implementation that multiplies each catalog row by the number of matching input rows. Verified: JOIN variant yields 10000 instead of 5000.

- [x] `npx tsc --noEmit` clean.
- [x] All 7 tests pass in `src/sync/pg-connector.test.ts`.

## Out of scope (separate finding)

`PgIdentifier.toString()` applies `quote_ident` semantics, so a mixed-case table name like `"Foo"` produces the quoted form `"Foo"` with double quotes. `pg_class.relname` stores the raw unquoted name (`Foo`), so `getTotalRowCount` will miss any mixed-case or reserved-word table. This is pre-existing behavior, not a regression from this fix — worth a separate ticket if it matters in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)