### PR TITLE
test: attach error listener to raw pg Pools in remote tests

### DIFF
--- a/src/remote/remote-controller.test.ts
+++ b/src/remote/remote-controller.test.ts
@@ -42,6 +42,7 @@ test("controller syncs correctly", async () => {
       const pool = new Pool({
         connectionString: innerRemote.optimizingDb.toString(),
       });
+      pool.on("error", () => {});
       const tablesAfter =
         await pool.query("select tablename from pg_tables where schemaname = 'public'");
       expect(tablesAfter.rowCount).toEqual(1);
@@ -92,6 +93,7 @@ test("creating an index via endpoint adds it to the optimizing db", async () => 
       const pool = new Pool({
         connectionString: innerRemote.optimizingDb.toString(),
       });
+      pool.on("error", () => {});
 
       // Verify no indexes exist initially
       const indexesBefore =

--- a/src/remote/remote.test.ts
+++ b/src/remote/remote.test.ts
@@ -96,6 +96,8 @@ test("syncs correctly", async () => {
       const pool = new Pool({
         connectionString: remote.optimizingDb.toString(),
       });
+      // Swallow late idle-client FATALs (57P01) when the container stops after pool.end()
+      pool.on("error", () => {});
 
       const indexesAfter =
         await pool.query("select indexname from pg_indexes where schemaname = 'public'");
@@ -394,6 +396,7 @@ test("schema loader detects changes after database modification", async () => {
       await using remote = new Remote(target, manager);
 
       const sourcePg = new Pool({ connectionString: source.toString() });
+      sourcePg.on("error", () => {});
 
       await remote.syncFrom(source);
       await remote.optimizer.finish;
@@ -497,6 +500,7 @@ test("getStatus returns latest schema after tables are added post-sync", async (
       await controller.onFullSync(source);
 
       const sourcePg = new Pool({ connectionString: source.toString() });
+      sourcePg.on("error", () => {});
 
       // Add many tables after the initial sync
       const createStatements = Array.from(
@@ -561,6 +565,7 @@ test("schema and deltas stay consistent across multiple polls", async () => {
       await using remote = new Remote(target, manager);
       const controller = new RemoteController(remote);
       const sourcePg = new Pool({ connectionString: source.toString() });
+      sourcePg.on("error", () => {});
 
       await controller.onFullSync(source);
 


### PR DESCRIPTION
## Summary
- Attach no-op `pool.on("error", ...)` on the five raw `new Pool(...)` instances in `remote.test.ts` and `remote-controller.test.ts`.

## Why
`pool.end()` resolves synchronously once `_clients` is empty, but the underlying `client.end()` is still async — the Terminate (X) may not have flushed when the testcontainer is stopped in the `finally` block. The server then sends FATAL 57P01 to the still-listening idle client, which re-emits on the Pool. Library pools go through `wrapPgPool` (`src/sql/postgresjs.ts:126`) which already installs a handler; the raw test Pools didn't, so the error escaped as unhandled and flaked CI even when every assertion passed.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/remote/remote.test.ts src/remote/remote-controller.test.ts` (13/13 green, no unhandled errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)