### PR TITLE
fix(deps): drop dumpStats "full" arg removed in core 0.8.7

### DIFF
--- a/src/remote/query-optimizer.ts
+++ b/src/remote/query-optimizer.ts
@@ -135,7 +135,7 @@ export class QueryOptimizer extends EventEmitter<EventMap> {
   ): Promise<void> {
     const version = PostgresVersion.parse("17");
     const pg = this.manager.getOrCreateConnection(this.connectable);
-    const ownStats = await Statistics.dumpStats(pg, version, "full");
+    const ownStats = await Statistics.dumpStats(pg, version);
     const statistics = new Statistics(pg, version, ownStats, statsMode);
     this.existingIndexes = await statistics.getExistingIndexes();
     const filteredIndexes = this.filterDisabledIndexes(this.existingIndexes);

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -332,7 +332,6 @@ export class Remote extends EventEmitter<RemoteEvents> {
     const stats = await Statistics.dumpStats(
       pg,
       PostgresVersion.parse("17"),
-      "full",
     );
     return { kind: "fromStatisticsExport", source: { kind: "inline" }, stats };
   }

--- a/src/sync/syncer.ts
+++ b/src/sync/syncer.ts
@@ -64,7 +64,7 @@ export class PostgresSyncer {
       { dependencies, serialized: serializedResult },
     ] = await Promise.all([
       withSpan("stats", () => {
-        return Statistics.dumpStats(sql, PostgresVersion.parse("17"), "full");
+        return Statistics.dumpStats(sql, PostgresVersion.parse("17"));
       })(),
       withSpan("getDatabaseInfo", () => {
         return connector.getDatabaseInfo();


### PR DESCRIPTION
## Summary
- `@query-doctor/core@0.8.7` dropped the third `mode` parameter from `Statistics.dumpStats`, breaking typecheck on `main` at three call sites.
- Removes the now-invalid `"full"` literal in `src/remote/query-optimizer.ts`, `src/remote/remote.ts`, and `src/sync/syncer.ts`.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` (24 files, 169 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)