### PR TITLE
fix: dont await optimizer.restart() on stats application

### DIFF
--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -359,7 +359,8 @@ export class Remote extends EventEmitter<RemoteEvents> {
 
   async applyStatistics(statsMode: StatisticsMode): Promise<void> {
     await this.optimizer.setStatistics(statsMode);
-    await this.optimizer.restart();
+    // don't block the reply by awaiting all optimizations
+    this.optimizer.restart();
   }
 
   async resetPgStatStatements(source: Connectable): Promise<void> {


### PR DESCRIPTION
Stats import shouldn't be waiting around for all queries to optimize