### PR TITLE
ci: pass TOKEN secret into local action env

### DIFF
--- a/.github/workflows/custom.yaml
+++ b/.github/workflows/custom.yaml
@@ -48,6 +48,7 @@ jobs:
           postgres-version: 17
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TOKEN: ${{ secrets.ANALYZER_CI_TOKEN }}
           SOURCE_DATABASE_URL: postgres://query_doctor@localhost:5432/testing
           LOG_PATH: /var/log/postgresql/postgres.log
           SITE_API_ENDPOINT: ${{ vars.SITE_API_ENDPOINT }}


### PR DESCRIPTION
## Summary
Plumb \`secrets.ANALYZER_CI_TOKEN\` into the \`Run local GitHub Action\` step in \`custom.yaml\`. The analyzer's CI mode calls \`runInCI\` which requires \`env.TOKEN\` to authenticate against the Site API over RPC; without it the run dies with \`Error: CI mode cannot be run without a TOKEN variable provided\`.

## Requires
- Repo secret \`ANALYZER_CI_TOKEN\` set to a Site project token (minted from \`GET /projects/:id/token\` on the prod Site API).
- \`vars.SITE_API_ENDPOINT\` pointing at the Site environment that owns the project the token belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)