### PR TITLE
fix: keep getQuerySource out of getRecentQueries after reset

### DIFF
--- a/src/sync/pg-connector.ts
+++ b/src/sync/pg-connector.ts
@@ -467,11 +467,15 @@ ORDER BY
   }
 
   private async getQuerySource(): Promise<QuerySourceExtension> {
+    // The marker must sit before the terminating semicolon — Postgres strips
+    // trailing comments past `;` from the text that pg_stat_statements stores,
+    // which would let this query bypass the introspection filter in
+    // getRecentQueries() and surface after pg_stat_statements_reset().
     const results = await this.db.exec<{ schema: string; extension: string }>(`
       SELECT e.extname as extension, n.nspname as schema
       FROM pg_extension e
       JOIN pg_namespace n ON n.oid = e.extnamespace
-      WHERE e.extname IN ('pg_stat_statements', 'pg_stat_monitor');
+      WHERE e.extname IN ('pg_stat_statements', 'pg_stat_monitor') -- @qd_introspection
     `);
     const firstResult = results[0];
     if (!firstResult) {


### PR DESCRIPTION
## Summary

- The non-default-schema reset test (`resetPgStatStatements works with a non-default schema`) was failing with `expected 1 to deeply equal +0` — one query survived `pg_stat_statements_reset()`.
- Root cause: `getQuerySource()` had no `@qd_introspection` marker AND its IN-list literals normalize to `$1, $2`, so neither filter in `getRecentQueries()` caught it.
- Adding `-- @qd_introspection` after the trailing `;` didn't help: Postgres strips trailing comments past `;` from the text pg_stat_statements stores (verified empirically). Moved the marker before the terminator so it actually survives.

## Test plan

- [x] `npx vitest run src/sync/pg-connector.test.ts` — all 7 tests pass locally against postgres:17
- [ ] Re-run the CI Release Action job and confirm it gets past this test