### PR TITLE
fix: implement ApiClient.resetStats to satisfy ClientApi

### DIFF
--- a/src/remote/api-client.ts
+++ b/src/remote/api-client.ts
@@ -165,6 +165,10 @@ export class ApiClient extends RpcTarget implements ClientApi {
     await this.remote.applyStatistics(Statistics.statsModeFromExport(stats));
   }
 
+  async resetStats(): Promise<void> {
+    await this.remote.applyStatistics(Statistics.defaultStatsMode);
+  }
+
   async hideIndex(indexName: string): Promise<void> {
     this.remote.optimizer.toggleIndex(PgIdentifier.fromString(indexName));
   }


### PR DESCRIPTION
The `@query-doctor/core` bump on `main` added `resetStats(): Promise<void>` to the `ClientApi` interface, which `ApiClient` implements but never defined — breaking `tsc --noEmit` and the `release` CI job. This adds `resetStats` as the natural inverse of `updateStatistics`, reverting the optimizer to `Statistics.defaultStatsMode` via the existing `Remote.applyStatistics`. Typecheck is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)