### PR TITLE
fix: omit roll-up line when the API returns a null baseline

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -456,4 +456,24 @@ describe("CI-signal metadata parity (analyzer#141)", () => {
     expect(output).toContain('More detail → get_ci_run({ runId: "9f3a1c20" })');
     expect(output).not.toContain(">docs</a>");
   });
+
+  test("degraded baseline (null rollup): roll-up line omitted, footer still rendered", () => {
+    // The Site API nulls rollup/rollupText when the comparison baseline read
+    // fails, but the baseline-independent footer/docs still ship. Omit the
+    // roll-up line entirely rather than render a blank line or "null".
+    const ctx = makeContext({
+      comparison: regressedComparison,
+      runUrl: "https://app.querydoctor.com/alice/proj/ci/9f3a1c20",
+      runMetadata: makeMetadata({ rollup: null, rollupText: null }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).not.toContain("regressed · ");
+    expect(output).not.toContain("null");
+    // Footer and run link are baseline-independent — they still render.
+    expect(output).toContain('More detail → get_ci_run({ runId: "9f3a1c20" })');
+    expect(output).toContain(
+      '<a href="https://app.querydoctor.com/alice/proj/ci/9f3a1c20">view run</a>',
+    );
+  });
 });

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -8,7 +8,7 @@
 
 > **No baseline on `{{ comparisonBranch }}`** — the analyzer cannot detect regressions without a previous run. To establish a baseline, add a `push` trigger for your comparison branch so the analyzer runs on merges to `{{ comparisonBranch }}`. See the [CI integration guide](https://docs.querydoctor.com/guides/ci-integration/#workflow-trigger) for setup instructions.
 {% endif %}
-{% if runMetadata %}
+{% if runMetadata and runMetadata.rollupText %}
 
 {{ runMetadata.rollupText }}
 {% endif %}

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -75,10 +75,19 @@ export interface PreviousRun {
  * language as the Slack/webhook alert. See analyzer#141.
  */
 export interface CiRunMetadata {
-  /** Structured roll-up counts. The rendered roll-up line must equal `rollupText`. */
-  rollup: { regressed: number; improved: number; new: number; removed: number };
-  /** The roll-up line — render verbatim (equals the alert's `formatRollup(...)`). */
-  rollupText: string;
+  /**
+   * Structured roll-up counts. The rendered roll-up line must equal `rollupText`.
+   * `null` when the API couldn't resolve the comparison baseline (a degraded read,
+   * distinct from a genuine all-new first run) — omit the roll-up line in that case.
+   */
+  rollup: {
+    regressed: number;
+    improved: number;
+    new: number;
+    removed: number;
+  } | null;
+  /** The roll-up line — render verbatim (equals the alert's `formatRollup(...)`). `null` when {@link rollup} is. */
+  rollupText: string | null;
   /** The small "more detail" footer — render verbatim (equals `formatRunFooter(runId)`). */
   footer: string;
   /** A small `docs` link. May be null. */


### PR DESCRIPTION
## Context

Companion to **Query-Doctor/Site#3156** (closes Site#3068). That PR makes `POST /ci/runs` degrade gracefully when the comparison-baseline read fails after the run row is inserted: instead of 500-ing a persisted run, it returns `{ id, url }` with `metadata.rollup` / `metadata.rollupText` set to **`null`** — explicitly "comparison unknown", distinct from a genuine all-new first run. The baseline-independent fields (`footer`, `docsUrl`, `signalKeys`, per-query `queries`) still ship.

The analyzer at `@main` consumes `rollupText`, but the success template guards the roll-up only with `{% if runMetadata %}`. On the degraded path `runMetadata` is present with `rollupText: null`, so nunjucks would render a **blank line** where the roll-up belongs.

## Change

- `success.md.j2`: guard the roll-up block on `runMetadata.rollupText` itself, so a null roll-up is omitted entirely (the footer/run-link row, gated separately, still renders).
- `site-api.ts`: mark `CiRunMetadata.rollup` and `.rollupText` nullable to match the Site contract, with a doc note that `null` means a degraded baseline (not a first run).
- Test: a degraded-baseline case (`rollup: null, rollupText: null`) asserts no roll-up line, no literal `"null"`, and that the footer + run link still render.

## Testing

- Reporter suites pass: `site-api.test.ts` + `github.test.ts`, 34 tests (existing snapshots unchanged — a truthy `rollupText` still renders identically).
- `tsc --noEmit` clean.

## Note

`null` only occurs on the API's error path (a baseline read actually throws); the happy path always populates the roll-up, so this is a rare, transient case. Related coordination: Site#3091 (deploy skew) — this should ride along with the analyzer release pin discussed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)