### PR TITLE
fix(ci): authenticate POST /ci/runs with the project token

### DIFF
--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -1,6 +1,7 @@
-import { test, expect, describe } from "vitest";
+import { test, expect, describe, afterEach, vi } from "vitest";
 import {
   compareRuns,
+  postToSiteApi,
   type CiQueryPayload,
   type PreviousRun,
 } from "./site-api.ts";
@@ -182,5 +183,45 @@ describe("compareRuns", () => {
       expect(result.improved[0].hash).toBe("hash-b");
       expect(result.disappearedHashes).toEqual(["hash-e"]);
     });
+  });
+});
+
+describe("postToSiteApi authentication", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  function stubOkFetch() {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "run-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  function headersFrom(fetchMock: ReturnType<typeof vi.fn>): Headers {
+    return new Headers(fetchMock.mock.calls[0]![1]!.headers);
+  }
+
+  test("sends the project token as a Bearer Authorization header", async () => {
+    vi.stubEnv("TOKEN", "tok-abc123");
+    const fetchMock = stubOkFetch();
+
+    await postToSiteApi("https://api.querydoctor.com", [makeQuery("hash-a")]);
+
+    expect(headersFrom(fetchMock).get("authorization")).toBe("Bearer tok-abc123");
+  });
+
+  test("omits the Authorization header when no token is set", async () => {
+    vi.stubEnv("TOKEN", "");
+    const fetchMock = stubOkFetch();
+
+    await postToSiteApi("https://api.querydoctor.com", [makeQuery("hash-a")]);
+
+    expect(headersFrom(fetchMock).has("authorization")).toBe(false);
   });
 });

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -298,13 +298,27 @@ export async function postToSiteApi(
     computedStats,
   };
 
+  // POST /ci/runs authenticates the run with the project token and attributes
+  // it to that project. Without the header the Site API rejects the request as
+  // Unauthorized, so warn loudly rather than silently dropping the run.
+  const token = process.env.TOKEN;
+  if (!token) {
+    console.warn(
+      "TOKEN is not set — POST /ci/runs will be rejected as Unauthorized. " +
+        "Set TOKEN to your Query Doctor project token.",
+    );
+  }
+
   const url = `${endpoint.replace(/\/$/, "")}/ci/runs`;
   console.log(`Posting CI run to ${url} (${queries.length} queries)`);
 
   try {
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
       body: JSON.stringify(payload),
     });
     if (!response.ok) {


### PR DESCRIPTION
## Problem

The Site API started requiring `Authorization: Bearer <project-token>` on `POST /ci/runs` as of the `2026-06-05` commit *"require project token for POST /ci/runs"*. `postToSiteApi` only ever sent `Content-Type`, so once that deployed **every** analyzer CI run is rejected:

```
Posting CI run to https://api.querydoctor.com/ci/runs (44 queries)
Site API responded with 401: {"message":"Unauthorized","statusCode":401}
```

This is fleet-wide, not repo-specific — the newest `ci_run` across all projects (site, nutcracker, …) is `2026-06-06 17:11`; ingestion stopped the moment the guard deployed. The `TOKEN` env was already documented as required and is what the websocket relay authenticates with; the HTTP run-post path just never used it.

## Fix

- Attach `Authorization: Bearer ${process.env.TOKEN}` to the `POST /ci/runs` request.
- Warn when `TOKEN` is unset rather than silently sending a request that will 401.

`fetchPreviousRun` (`GET /ci/runs/latest`) is unguarded and unaffected, so it's left as-is.

## Verification

- New tests assert the `Bearer` header is sent when `TOKEN` is set and omitted when not.
- `npm test -- run src/reporters/site-api.test.ts` → 12 passed; `npm run typecheck` → clean.
- Validated end-to-end against prod: `curl` to `POST /ci/runs` with a valid project token passes auth (400 on empty body), bogus token → 401. With this header the analyzer's post will authenticate identically.

Core is unchanged; `@query-doctor/core` stays at `0.10.3` (matches Site `packages/core` and npm latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)