### PR TITLE
feat: gate new queries on high-impact index recommendations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   buildQueries,
   compareRuns,
   fetchPreviousRun,
+  gateEligibleNewQueries,
   postToSiteApi,
 } from "./reporters/site-api.ts";
 import { formatCost, queryPreview } from "./reporters/github/github.ts";
@@ -140,21 +141,57 @@ async function runInCI(
     // Generate PR comment with comparison data
     await runner.report(reportContext);
 
-    // Block PR if regressions exceed thresholds
-    if (reportContext.comparison && reportContext.comparison.regressed.length > 0) {
+    // Block PR if regressions exceed thresholds, or if a brand-new query ships
+    // with a high-confidence index recommendation (#3281). New queries have no
+    // baseline so they can never regress; the new-query gate catches the missing
+    // index at introduction, while it's still a one-line fix.
+    if (reportContext.comparison) {
       const queryLinks = new Map(
         (reportContext.runMetadata?.queries ?? []).map((q) => [q.hash, q.link]),
       );
-      const messages = reportContext.comparison.regressed.map((q) => {
-        const preview = queryPreview(q.formattedQuery);
-        const cost = `cost ${formatCost(q.previousCost)} → ${formatCost(q.currentCost)} (+${q.regressionPercentage.toFixed(1)}%)`;
-        const queryLink = queryLinks.get(q.hash);
-        const link = queryLink ? `\n    ${queryLink}` : "";
-        return `  - ${preview}: ${cost}${link}`;
-      });
-      core.setFailed(
-        `${reportContext.comparison.regressed.length} untriaged regression(s) beyond threshold:\n${messages.join("\n")}`,
+      const linkFor = (hash: string) => {
+        const queryLink = queryLinks.get(hash);
+        return queryLink ? `\n    ${queryLink}` : "";
+      };
+
+      const blockingMessages: string[] = [];
+
+      const { regressed, newQueries } = reportContext.comparison;
+      if (regressed.length > 0) {
+        const messages = regressed.map((q) => {
+          const preview = queryPreview(q.formattedQuery);
+          const cost = `cost ${formatCost(q.previousCost)} → ${formatCost(q.currentCost)} (+${q.regressionPercentage.toFixed(1)}%)`;
+          return `  - ${preview}: ${cost}${linkFor(q.hash)}`;
+        });
+        blockingMessages.push(
+          `${regressed.length} untriaged regression(s) beyond threshold:\n${messages.join("\n")}`,
+        );
+      }
+
+      const gateNewQueries = gateEligibleNewQueries(
+        newQueries,
+        config.regressionThreshold,
+        config.acknowledgedQueryHashes,
       );
+      if (gateNewQueries.length > 0) {
+        const messages = gateNewQueries.map((q) => {
+          const preview = queryPreview(q.formattedQuery);
+          // gateEligibleNewQueries only returns improvements_available entries.
+          const opt = q.optimization as Extract<
+            typeof q.optimization,
+            { state: "improvements_available" }
+          >;
+          const detail = `cost ${formatCost(opt.cost)}, index recommendation cuts it ${opt.costReductionPercentage.toFixed(1)}%`;
+          return `  - ${preview}: ${detail}${linkFor(q.hash)}`;
+        });
+        blockingMessages.push(
+          `${gateNewQueries.length} new quer${gateNewQueries.length === 1 ? "y" : "ies"} ship${gateNewQueries.length === 1 ? "s" : ""} with a high-impact index recommendation (acknowledge on the dashboard to allow):\n${messages.join("\n")}`,
+        );
+      }
+
+      if (blockingMessages.length > 0) {
+        core.setFailed(blockingMessages.join("\n\n"));
+      }
     }
   } finally {
     disposeApi();

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, afterEach, vi } from "vitest";
 import {
   compareRuns,
+  gateEligibleNewQueries,
   postToSiteApi,
   type CiQueryPayload,
   type PreviousRun,
@@ -223,5 +224,82 @@ describe("postToSiteApi authentication", () => {
     await postToSiteApi("https://api.querydoctor.com", [makeQuery("hash-a")]);
 
     expect(headersFrom(fetchMock).has("authorization")).toBe(false);
+  });
+});
+
+describe("gateEligibleNewQueries", () => {
+  function withRecommendation(
+    hash: string,
+    costReductionPercentage: number,
+    hasIndexRecommendation = true,
+  ): CiQueryPayload {
+    return {
+      hash,
+      query: "SELECT * FROM t WHERE user_id = $1",
+      formattedQuery: "SELECT *\nFROM t\nWHERE user_id = $1",
+      optimization: {
+        state: "improvements_available",
+        cost: 407_000,
+        optimizedCost: 8.2,
+        costReductionPercentage,
+        indexRecommendations: hasIndexRecommendation
+          ? [
+            {
+              schema: "public",
+              table: "t",
+              columns: [{ schema: "public", table: "t", column: "user_id" }],
+              definition: "CREATE INDEX ON t (user_id)",
+            },
+          ]
+          : [],
+        indexesUsed: [],
+      },
+      nudges: [],
+      tags: [],
+      tableReferences: [],
+    };
+  }
+
+  test("flags a new query whose recommendation exceeds regressionThreshold", () => {
+    const result = gateEligibleNewQueries([withRecommendation("a", 99)], 90);
+
+    expect(result.map((q) => q.hash)).toEqual(["a"]);
+  });
+
+  test("with regressionThreshold 0 (flag-all), any real recommendation blocks", () => {
+    const result = gateEligibleNewQueries([withRecommendation("a", 99)], 0);
+
+    expect(result.map((q) => q.hash)).toEqual(["a"]);
+  });
+
+  test("ignores a recommendation at or below regressionThreshold", () => {
+    const result = gateEligibleNewQueries([withRecommendation("a", 40)], 90);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("ignores a query with no index recommendation (e.g. test-only query)", () => {
+    const result = gateEligibleNewQueries(
+      [withRecommendation("a", 99, false)],
+      90,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("ignores a query with no available improvement", () => {
+    const result = gateEligibleNewQueries([makeQuery("a")], 90);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("acknowledged hashes are exempt", () => {
+    const result = gateEligibleNewQueries(
+      [withRecommendation("a", 99), withRecommendation("b", 99)],
+      90,
+      ["a"],
+    );
+
+    expect(result.map((q) => q.hash)).toEqual(["b"]);
   });
 });

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -281,6 +281,38 @@ export function compareRuns(
   };
 }
 
+/**
+ * New queries that should block the CI gate (#3281). A new query has no
+ * baseline, so it can never be a regression and historically shipped green at
+ * any cost. We instead gate it on a *recommendation-backed* signal: the planner
+ * found a real index that collapses its cost. This keys on plan shape, not the
+ * raw modeled cost, so it survives the `fromAssumption` row-count inflation and
+ * naturally excludes test-only queries (which carry no index recommendation).
+ *
+ * Reuses the same `regressionThreshold` the existing gate already uses — no new
+ * knob: eligible when the query carries an index recommendation whose modeled
+ * cost reduction exceeds `regressionThreshold` percent, mirroring how a
+ * regression must exceed that same percentage. Acknowledged hashes are exempt,
+ * the same triage escape hatch regressions have; ignored hashes never reach here
+ * (they're dropped in {@link buildQueries}).
+ */
+export function gateEligibleNewQueries(
+  newQueries: CiQueryPayload[],
+  regressionThreshold: number,
+  acknowledgedQueryHashes: string[] = [],
+): CiQueryPayload[] {
+  const acknowledgedSet = new Set(acknowledgedQueryHashes);
+  return newQueries.filter((q) => {
+    if (acknowledgedSet.has(q.hash)) return false;
+    const opt = q.optimization;
+    return (
+      opt.state === "improvements_available" &&
+      opt.indexRecommendations.length > 0 &&
+      opt.costReductionPercentage > regressionThreshold
+    );
+  });
+}
+
 export async function postToSiteApi(
   endpoint: string,
   queries: CiQueryPayload[],


### PR DESCRIPTION
## What

Closes Query-Doctor/Site#3281. The CI gate only fails on **untriaged regressions**, which require a baseline cost. A brand-new query has none, so it ships green at any cost — even when carrying a strong index recommendation. This makes new queries gate-eligible **and** explains the block in the PR comment.

## Approach — no new config

Reuses the **existing `regressionThreshold`** already in the repo config. A new query blocks when it carries an index recommendation whose modeled cost-reduction **exceeds `regressionThreshold`%** — mirroring how a regression must exceed that same percentage. **No new setting, no Site/core/DB/schema change.**

- `gateEligibleNewQueries` (`reporters/site-api.ts`) — new queries with an index recommendation over `regressionThreshold`, minus acknowledged hashes (ignored hashes are already dropped in `buildQueries`). Keys on plan shape, not raw cost → survives `fromAssumption` inflation and excludes test-only queries.
- `main.ts` — the gate now fails the step on regressions **OR** gate-eligible new queries, in one combined `core.setFailed`. Acknowledging a query on the dashboard lets it through.

## PR comment parity

Without this, the gate is a **silent red X** — the originating trust problem (#3281: "a gate you have to manually double-check isn't doing its job"). So the comment now explains it:

- `buildViewModel` splits new-query recommendations into **blocking** (gate-eligible) vs informational.
- The template renders a dedicated **"introduces queries missing an index — blocking"** section next to regressions, telling the reader to add the index or acknowledge on the dashboard.

## Behaviour note

The new-query gate is tied to `regressionThreshold`, so it's active wherever regression gating is. If that's too noisy in practice, an independent tune/disable knob is tracked in Query-Doctor/Site#3285 (with a real confidence score and a `warn` mode).

## Testing

`tsc --noEmit` clean; full `vitest` suite green. Added `gateEligibleNewQueries` tests, a `buildViewModel` partition test, and template render tests (blocking section present/absent). Snapshots updated (one extra blank line in the empty case; GitHub collapses it).