### PR TITLE
fix: forward PR base branch to the Site roll-up

### DIFF
--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -227,6 +227,46 @@ describe("postToSiteApi authentication", () => {
   });
 });
 
+describe("postToSiteApi payload baseBranch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  function stubOkFetch() {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "run-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  function bodyFrom(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+    return JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+  }
+
+  test("forwards GITHUB_BASE_REF as baseBranch on a PR run", async () => {
+    vi.stubEnv("GITHUB_BASE_REF", "main");
+    const fetchMock = stubOkFetch();
+
+    await postToSiteApi("https://api.querydoctor.com", [makeQuery("hash-a")]);
+
+    expect(bodyFrom(fetchMock).baseBranch).toBe("main");
+  });
+
+  test("omits baseBranch on a push run where GITHUB_BASE_REF is unset", async () => {
+    vi.stubEnv("GITHUB_BASE_REF", "");
+    const fetchMock = stubOkFetch();
+
+    await postToSiteApi("https://api.querydoctor.com", [makeQuery("hash-a")]);
+
+    expect(bodyFrom(fetchMock)).not.toHaveProperty("baseBranch");
+  });
+});
+
 describe("gateEligibleNewQueries", () => {
   function withRecommendation(
     hash: string,

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -6,6 +6,12 @@ import type { OptimizedQuery } from "../sql/recent-query.ts";
 interface CiRunPayload {
   repo: string;
   branch: string;
+  /**
+   * The PR base branch (`GITHUB_BASE_REF`), forwarded so the Site roll-up
+   * resolves the same baseline the PR-comment body already used. Absent on
+   * push runs, where there is no base ref. See Query-Doctor/Site#3292.
+   */
+  baseBranch?: string;
   commitSha: string;
   commitMessage?: string;
   prNumber?: number;
@@ -322,6 +328,9 @@ export async function postToSiteApi(
   const payload: CiRunPayload = {
     repo: process.env.GITHUB_REPOSITORY ?? "",
     branch: process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME || "",
+    // Forward the PR base ref so the Site roll-up compares against the same
+    // baseline as the PR-comment body. Empty/unset on push runs → omitted.
+    baseBranch: process.env.GITHUB_BASE_REF || undefined,
     commitSha: process.env.GITHUB_SHA ?? "",
     prNumber: github.context.payload.pull_request?.number,
     runId: process.env.GITHUB_RUN_ID ?? "",


### PR DESCRIPTION
## What

Forward `GITHUB_BASE_REF` as a new `baseBranch` field on the `POST /ci/runs` payload so the Site roll-up resolves the **same baseline** as the PR-comment body.

## Why

On a re-push PR, the Site roll-up (`computeRollup`) had no knowledge of the PR base branch — its payload carried only the head branch. It therefore compared head-vs-its-own-previous-push and collapsed to an all-zero roll-up:

> 59 queries analyzed | 22 new queries
> **0 regressed · 0 improved · 0 new · 0 removed**
> _(followed by a long list of new queries with blocking index recommendations)_

The analyzer's own body comparison already falls back to `GITHUB_BASE_REF`, which is why only the roll-up line was wrong. Forwarding the base ref lets Site mirror the analyzer's `comparisonBranch ?? GITHUB_BASE_REF ?? branch` precedence.

## Change

- `CiRunPayload` gains an optional `baseBranch`.
- The payload sends `baseBranch: process.env.GITHUB_BASE_REF || undefined` — omitted on push runs where there is no base ref.

## Cross-repo

Ships together with **Query-Doctor/Site#3292** (the Site half that reads `baseBranch`). Each half is a no-op without the other:
- This PR alone: Site ignores the new field → unchanged behaviour.
- Site PR alone: `baseBranch` is undefined → falls back to head branch → unchanged behaviour.

## Tests

`postToSiteApi` payload tests: forwards `baseBranch` when `GITHUB_BASE_REF` is set; omits it on a push run. Full unit suite (`site-api.test.ts`, 20 tests) green; typecheck clean. (The repo's testcontainer integration suites are unaffected by this reporter-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)