### PR TITLE
feat: periodic schema polling

### DIFF
--- a/src/remote/metadata-loader.ts
+++ b/src/remote/metadata-loader.ts
@@ -1,0 +1,31 @@
+import type { EventEmitter } from "node:events";
+
+/**
+ * Events shared by every {@link MetadataLoader}. Loader-specific payload events
+ * (e.g. the query loader's `poll`, the schema loader's `diff`) are layered on
+ * top via the `Events` parameter.
+ */
+export type MetadataLoaderEvents = {
+  /** A single poll failed. The loader keeps running until `maxErrors`. */
+  pollError: [unknown];
+  /** The loader stopped polling for good (too many consecutive errors). */
+  exit: [];
+};
+
+/**
+ * A source of remote metadata that we keep current by polling on a timer.
+ * Both {@link QueryLoader} and {@link SchemaLoader} implement this so `Remote`
+ * can drive them through one lifecycle regardless of what they track.
+ */
+export interface MetadataLoader<
+  Events extends MetadataLoaderEvents & Record<keyof Events, unknown[]> =
+    MetadataLoaderEvents,
+> extends EventEmitter<Events> {
+  /** Begin polling on the configured interval. */
+  start(): void;
+  /**
+   * Stop polling. In-flight requests are allowed to complete; no further polls
+   * are scheduled.
+   */
+  stop(): void;
+}

--- a/src/remote/query-loader.ts
+++ b/src/remote/query-loader.ts
@@ -3,15 +3,15 @@ import { Connectable } from "../sync/connectable.ts";
 import { ConnectionManager } from "../sync/connection-manager.ts";
 import { RecentQuery } from "../sql/recent-query.ts";
 import { ExtensionNotInstalledError } from "../sync/errors.ts";
+import type { MetadataLoader, MetadataLoaderEvents } from "./metadata-loader.ts";
 
-export type QueryLoaderEvents = {
+export type QueryLoaderEvents = MetadataLoaderEvents & {
   poll: [RecentQuery[]];
-  pollError: [unknown];
   pgStatStatementsNotInstalled: [];
-  exit: [];
 };
 
-export class QueryLoader extends EventEmitter<QueryLoaderEvents> {
+export class QueryLoader extends EventEmitter<QueryLoaderEvents>
+  implements MetadataLoader<QueryLoaderEvents> {
   private consecutiveErrors = 0;
   private stopped = false;
   private readonly interval: number;

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -29,6 +29,7 @@ type RemoteEvents = {
   extensionPresenceChanged: [presence: ExtensionPresence];
   queriesPolled: [queries: RecentQuery[]];
   schemaSynced: [schema: FullSchema];
+  schemaDiffed: [diffs: Op[], schema: FullSchema];
   statsApplied: [stats: ExportedStats[]];
   queryError: [error: Error, query: OptimizedQuery];
 };
@@ -429,8 +430,22 @@ export class Remote extends EventEmitter<RemoteEvents> {
     if (this.queryLoader) {
       this.queryLoader.stop();
     }
+    if (this.schemaLoader) {
+      this.schemaLoader.stop();
+    }
     this.queryLoader = new QueryLoader(this.sourceManager, source);
     this.schemaLoader = new SchemaLoader(this.sourceManager, source);
+    this.schemaLoader.on("diff", (diffs, schema) => {
+      this.emit("schemaDiffed", diffs, schema);
+    });
+    this.schemaLoader.on("pollError", (error) => {
+      log.error("Failed to poll schema", "remote");
+      console.error(error);
+    });
+    this.schemaLoader.on("exit", () => {
+      log.error("Schema loader exited", "remote");
+      this.schemaLoader = undefined;
+    });
     this.queryLoader.on("pollError", (error) => {
       log.error("Failed to poll queries", "remote");
       console.error(error);
@@ -456,11 +471,13 @@ export class Remote extends EventEmitter<RemoteEvents> {
     });
     if (!this.options.disableQueryLoader) {
       this.queryLoader.start();
+      this.schemaLoader.start();
     }
   }
 
   async cleanup(): Promise<void> {
     this.queryLoader?.stop();
+    this.schemaLoader?.stop();
     await this.optimizer.finish;
     this.optimizer.stop();
     await Promise.all([

--- a/src/remote/schema-loader.test.ts
+++ b/src/remote/schema-loader.test.ts
@@ -1,0 +1,138 @@
+import { test, expect, vi, afterEach } from "vitest";
+import { Connectable } from "../sync/connectable.ts";
+import { ConnectionManager } from "../sync/connection-manager.ts";
+import { SchemaLoader } from "./schema-loader.ts";
+import type { FullSchema, Postgres } from "@query-doctor/core";
+import { dumpSchema } from "@query-doctor/core";
+import type { Op } from "jsondiffpatch/formatters/jsonpatch";
+
+vi.mock(import("@query-doctor/core"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, dumpSchema: vi.fn() };
+});
+
+const mockedDumpSchema = vi.mocked(dumpSchema);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function makeSchema(overrides?: Partial<FullSchema>): FullSchema {
+  return {
+    indexes: [],
+    tables: [],
+    constraints: [],
+    functions: [],
+    extensions: [],
+    views: [],
+    types: [],
+    triggers: [],
+    ...overrides,
+  };
+}
+
+function makeLoader() {
+  const manager = ConnectionManager.forRemoteDatabase();
+  const connectable = Connectable.fromString("postgres://localhost:5432/test");
+  vi.spyOn(manager, "getOrCreateConnection").mockReturnValue({} as Postgres);
+  return new SchemaLoader(manager, connectable);
+}
+
+test("SchemaLoader - poll diffs against the previously seen schema", async () => {
+  const loader = makeLoader();
+
+  mockedDumpSchema.mockResolvedValueOnce(makeSchema());
+  const first = await loader.poll();
+  expect(first.diffs).toEqual([]);
+
+  mockedDumpSchema.mockResolvedValueOnce(
+    makeSchema({ tables: [{ type: "table", oid: 1 } as never] }),
+  );
+  const second = await loader.poll();
+  expect(second.diffs.length).toBeGreaterThan(0);
+  expect(loader.getLatestSchema()?.tables.length).toEqual(1);
+});
+
+test("SchemaLoader - start emits diff on schema change", async () => {
+  vi.useFakeTimers();
+  const loader = makeLoader();
+
+  mockedDumpSchema.mockResolvedValueOnce(makeSchema());
+  mockedDumpSchema.mockResolvedValueOnce(
+    makeSchema({ tables: [{ type: "table", oid: 1 } as never] }),
+  );
+
+  const diffs: Op[][] = [];
+  loader.on("diff", (ops) => diffs.push(ops));
+
+  loader.start();
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(diffs.length).toEqual(0);
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(diffs.length).toEqual(1);
+
+  loader.stop();
+});
+
+test("SchemaLoader - does not emit diff when schema is unchanged", async () => {
+  vi.useFakeTimers();
+  const loader = makeLoader();
+
+  mockedDumpSchema.mockResolvedValue(makeSchema());
+
+  const diffs: Op[][] = [];
+  loader.on("diff", (ops) => diffs.push(ops));
+
+  loader.start();
+  await vi.advanceTimersByTimeAsync(180_000);
+
+  expect(diffs.length).toEqual(0);
+  loader.stop();
+});
+
+test("SchemaLoader - stop prevents further polling", async () => {
+  vi.useFakeTimers();
+  const loader = makeLoader();
+  mockedDumpSchema.mockClear();
+  mockedDumpSchema.mockResolvedValue(makeSchema());
+
+  let pollCount = 0;
+  loader.on("diff", () => pollCount++);
+
+  loader.start();
+  loader.stop();
+
+  await vi.advanceTimersByTimeAsync(120_000);
+  expect(mockedDumpSchema).not.toHaveBeenCalled();
+  expect(pollCount).toEqual(0);
+});
+
+test("SchemaLoader - exits after maxErrors consecutive errors", async () => {
+  vi.useFakeTimers();
+  const manager = ConnectionManager.forRemoteDatabase();
+  const connectable = Connectable.fromString("postgres://localhost:5432/test");
+  vi.spyOn(manager, "getOrCreateConnection").mockReturnValue({} as Postgres);
+  const loader = new SchemaLoader(manager, connectable, { maxErrors: 1, interval: 1_000 });
+
+  mockedDumpSchema.mockRejectedValue(new Error("dump failed"));
+
+  const pollErrors: unknown[] = [];
+  const exits: number[] = [];
+  loader.on("pollError", (error) => pollErrors.push(error));
+  loader.on("exit", () => exits.push(Date.now()));
+
+  loader.start();
+
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(pollErrors.length).toEqual(1);
+  expect(exits.length).toEqual(0);
+
+  await vi.advanceTimersByTimeAsync(1_000);
+  expect(pollErrors.length).toEqual(2);
+  expect(exits.length).toEqual(1);
+
+  loader.stop();
+});

--- a/src/remote/schema-loader.ts
+++ b/src/remote/schema-loader.ts
@@ -1,13 +1,32 @@
+import { EventEmitter } from "node:events";
 import { Connectable } from "../sync/connectable.ts";
 import { ConnectionManager } from "../sync/connection-manager.ts";
 import { SchemaDiffer } from "../sync/schema_differ.ts";
 import { dumpSchema, FullSchema } from "@query-doctor/core";
+import { type Op } from "jsondiffpatch/formatters/jsonpatch";
+import type { MetadataLoader, MetadataLoaderEvents } from "./metadata-loader.ts";
 
-export class SchemaLoader {
+export type SchemaLoaderEvents = MetadataLoaderEvents & {
+  diff: [diffs: Op[], schema: FullSchema];
+};
+
+export class SchemaLoader extends EventEmitter<SchemaLoaderEvents>
+  implements MetadataLoader<SchemaLoaderEvents> {
+  private consecutiveErrors = 0;
+  private stopped = false;
+  private readonly interval: number;
+  private readonly maxErrors: number;
+  private timer?: ReturnType<typeof setTimeout>;
+
   constructor(
     private readonly sourceManager: ConnectionManager,
     private readonly connectable: Connectable,
-  ) { }
+    options?: { maxErrors?: number; interval?: number },
+  ) {
+    super();
+    this.maxErrors = options?.maxErrors ?? 3;
+    this.interval = options?.interval ?? 60_000;
+  }
 
   private readonly differ = new SchemaDiffer();
   private latestSchema?: FullSchema;
@@ -26,5 +45,67 @@ export class SchemaLoader {
   update(schema: FullSchema) {
     this.latestSchema = schema;
     return this.differ.put(this.connectable, schema);
+  }
+
+  start() {
+    this.scheduleNextPoll();
+  }
+
+  /**
+   * Schedules the loader to stop. Any in-flight requests
+   * will attempt to complete
+   */
+  stop() {
+    this.stopped = true;
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  /**
+   * Dump the schema once, diff it against the last seen schema, and emit any
+   * deltas. Mirrors {@link QueryLoader.poll} so the schema is tracked on the
+   * same lifecycle as queries.
+   * @returns whether the loader should keep polling. Also emitted via `exit`.
+   */
+  private async pollOnce(): Promise<boolean> {
+    try {
+      const { diffs } = await this.poll();
+      this.consecutiveErrors = 0;
+      if (diffs.length > 0 && this.latestSchema) {
+        this.emit("diff", diffs, this.latestSchema);
+      }
+    } catch (error) {
+      this.consecutiveErrors++;
+      this.emit("pollError", error);
+    }
+    if (this.consecutiveErrors > this.maxErrors) {
+      this.emit("exit");
+      return false;
+    }
+    return true;
+  }
+
+  private scheduleNextPoll() {
+    if (this.stopped) {
+      return;
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      if (this.stopped) {
+        return;
+      }
+      this.pollOnce().then((ok) => {
+        if (ok) {
+          this.scheduleNextPoll();
+        }
+      }, (error) => {
+        console.error(error);
+        // we don't expect an error here. Better signal our exit
+        this.emit("exit");
+      });
+    }, this.interval);
   }
 }


### PR DESCRIPTION
Following the pattern of the `QueryLoader` I've added a polling interval to the SchemaLoader. This is the first leg of the required work that will allow analyzer to sync schemas and diffs periodically. I think I'm okay with sending the entire schema every time and letting the backend figure out whether anything has changed since the last schema pull. That might require us to move the `SchemaDiffer` class to the API since we don't expect analyzer to store anything about the db it's exposing