### PR TITLE
fix: retry transient baseline fetch, distinguish it from a missing baseline

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -120,10 +120,14 @@ async function runInCI(
           `(add "push: branches: [${comparisonBranch}]" to your workflow trigger).`,
         );
       } else {
+        // Transient fetch failure after retries — flag it so the comment says
+        // "temporarily unavailable, re-run" rather than claiming there is no
+        // baseline (which would tell the user to add an already-present trigger).
+        reportContext.comparisonUnavailable = true;
         log.warn(
           "main",
           `Failed to fetch baseline for branch "${comparisonBranch}" (${result.reason}). ` +
-          `Comparison will be skipped. This is likely a transient Site API issue — re-run the check to retry.`,
+          `Comparison will be skipped this run — re-run the check to retry.`,
         );
       }
     }

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -477,3 +477,28 @@ describe("CI-signal metadata parity (analyzer#141)", () => {
     );
   });
 });
+
+describe("baseline absent vs. temporarily unavailable (Site#3287)", () => {
+  test("genuine missing baseline renders the no-baseline / push-trigger copy", () => {
+    const ctx = makeContext({ comparisonBranch: "staging" });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("No baseline on `staging`");
+    expect(output).toContain("add a `push` trigger");
+    expect(output).not.toContain("temporarily unavailable");
+  });
+
+  test("transient fetch failure renders a re-run message, not the no-baseline copy", () => {
+    const ctx = makeContext({
+      comparisonBranch: "staging",
+      comparisonUnavailable: true,
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("comparison temporarily unavailable");
+    expect(output).toContain("re-run the check");
+    // Must not tell the user to add a trigger that is already in place.
+    expect(output).not.toContain("No baseline on `staging`");
+    expect(output).not.toContain("add a `push` trigger");
+  });
+});

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -3,6 +3,10 @@
 {% if hasComparison %}
 {{ queryStats.analyzed | default('?') }} queries analyzed
 {%- if newQueryCount > 0 %} | {{ newQueryCount }} new quer{{ "ies" if newQueryCount != 1 else "y" }}{% endif %}
+{% elif comparisonUnavailable %}
+{{ queryStats.analyzed | default('?') }} queries analyzed — comparison temporarily unavailable.
+
+> **Couldn't load the baseline for `{{ comparisonBranch }}` this run**, so the comparison was skipped. This is temporary and doesn't mean the baseline is missing — re-run the check to retry.
 {% else %}
 {{ queryStats.analyzed | default('?') }} queries analyzed — no baseline found to compare against.
 

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -83,6 +83,13 @@ export interface ReportContext {
   error?: Error;
   comparison?: RunComparison;
   comparisonBranch?: string;
+  /**
+   * The baseline fetch failed transiently (timeout/5xx) after retries, so the
+   * comparison was skipped this run — distinct from a genuine missing baseline.
+   * Drives a "temporarily unavailable, re-run" message instead of the
+   * "no baseline / add a push trigger" copy (Site#3287).
+   */
+  comparisonUnavailable?: boolean;
   /** The run page link (`metadata.url` from `POST /ci/runs`). Absent when the repo isn't linked. */
   runUrl?: string;
   /** Unified CI-signal metadata: roll-up line, footer, per-query links, docs link, icon keys. */

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, afterEach, vi } from "vitest";
 import {
   compareRuns,
+  fetchPreviousRun,
   gateEligibleNewQueries,
   postToSiteApi,
   type CiQueryPayload,
@@ -341,5 +342,119 @@ describe("gateEligibleNewQueries", () => {
     );
 
     expect(result.map((q) => q.hash)).toEqual(["b"]);
+  });
+});
+
+describe("fetchPreviousRun retry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const foundResponse = () =>
+    new Response(
+      JSON.stringify({
+        id: "run-1",
+        repo: "org/repo",
+        branch: "main",
+        commitSha: "abc",
+        queries: [],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  test("retries a transient timeout and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new DOMException("timeout", "TimeoutError"))
+      .mockResolvedValueOnce(foundResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchPreviousRun(
+      "https://api.querydoctor.com",
+      "org/repo",
+      "main",
+      undefined,
+      { retryDelayMs: 0 },
+    );
+
+    expect(result).toEqual({
+      kind: "found",
+      run: { id: "run-1", repo: "org/repo", branch: "main", commitSha: "abc", queries: [] },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries a 5xx and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("upstream", { status: 503 }))
+      .mockResolvedValueOnce(foundResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchPreviousRun(
+      "https://api.querydoctor.com",
+      "org/repo",
+      "main",
+      undefined,
+      { retryDelayMs: 0 },
+    );
+
+    expect(result.kind).toBe("found");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry a genuine 404 — returns not-found on the first call", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchPreviousRun(
+      "https://api.querydoctor.com",
+      "org/repo",
+      "main",
+      undefined,
+      { retryDelayMs: 0 },
+    );
+
+    expect(result).toEqual({ kind: "not-found" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not retry a non-404 4xx — returns error on the first call", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchPreviousRun(
+      "https://api.querydoctor.com",
+      "org/repo",
+      "main",
+      undefined,
+      { retryDelayMs: 0 },
+    );
+
+    expect(result).toEqual({ kind: "error", reason: "HTTP 400" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns error after exhausting retries on persistent transient failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new DOMException("timeout", "TimeoutError"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchPreviousRun(
+      "https://api.querydoctor.com",
+      "org/repo",
+      "main",
+      undefined,
+      { retries: 2, retryDelayMs: 0 },
+    );
+
+    expect(result.kind).toBe("error");
+    // initial attempt + 2 retries
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -389,33 +389,69 @@ export type PreviousRunResult =
   | { kind: "not-found" }
   | { kind: "error"; reason: string };
 
+export interface FetchPreviousRunOptions {
+  /** Retry attempts after the first, on transient failures only. */
+  retries?: number;
+  /** Backoff before each retry. Pass 0 in tests. */
+  retryDelayMs?: number;
+}
+
+const delay = (ms: number) =>
+  ms > 0 ? new Promise<void>((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+
+/**
+ * Fetch the baseline run for a branch, distinguishing three outcomes:
+ * `found`, a genuine `not-found` (404), and a transient `error`.
+ *
+ * The baseline fetch pulls a multi-MB payload under a 10s timeout, so a brief
+ * latency blip times out and used to report "no baseline" on a baseline that
+ * demonstrably exists (Site#3287). Retry transient failures — timeout, network,
+ * or 5xx — before giving up; a genuine 404 (no baseline) and other 4xx are
+ * returned immediately and never retried.
+ */
 export async function fetchPreviousRun(
   endpoint: string,
   repo: string,
   branch?: string,
   excludeId?: string,
+  options: FetchPreviousRunOptions = {},
 ): Promise<PreviousRunResult> {
+  const { retries = 2, retryDelayMs = 500 } = options;
   const params = new URLSearchParams({ repo });
   if (branch) params.set("branch", branch);
   if (excludeId) params.set("excludeId", excludeId);
   const url = `${endpoint.replace(/\/$/, "")}/ci/runs/latest?${params}`;
   console.log(`Fetching previous run from ${url}`);
 
-  try {
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(10000),
-    });
-    if (response.status === 404) {
-      console.log("No previous run found");
-      return { kind: "not-found" };
+  let lastReason = "unknown";
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) {
+      console.log(`Retrying baseline fetch (attempt ${attempt + 1}/${retries + 1})`);
+      await delay(retryDelayMs);
     }
-    if (!response.ok) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(10000),
+      });
+      if (response.status === 404) {
+        console.log("No previous run found");
+        return { kind: "not-found" };
+      }
+      if (response.ok) {
+        return { kind: "found", run: (await response.json()) as PreviousRun };
+      }
+      // 5xx is transient (retry); other non-ok statuses (e.g. 4xx) won't fix
+      // themselves on a retry, so fail fast.
+      lastReason = `HTTP ${response.status}`;
       console.warn(`Failed to fetch previous run: ${response.status}`);
-      return { kind: "error", reason: `HTTP ${response.status}` };
+      if (response.status < 500) {
+        return { kind: "error", reason: lastReason };
+      }
+    } catch (err) {
+      // Timeout / network error — transient, keep retrying.
+      lastReason = `${err}`;
+      console.warn(`Failed to fetch previous run: ${err}`);
     }
-    return { kind: "found", run: (await response.json()) as PreviousRun };
-  } catch (err) {
-    console.warn(`Failed to fetch previous run: ${err}`);
-    return { kind: "error", reason: `${err}` };
   }
+  return { kind: "error", reason: lastReason };
 }


### PR DESCRIPTION
Closes Query-Doctor/Site#3287.

## Problem

The analyzer's PR comment showed **"no baseline found to compare against"** whenever the baseline fetch failed for *any* reason — including a transient 10s timeout — not just a genuine absence. A baseline that demonstrably existed got reported as missing, and the comment told the user to "add a push trigger" that was already in place (observed on Site PR #3284, where `staging` had a baseline recorded ~9h earlier).

Root cause: `fetchPreviousRun` did a single `fetch` with a 10s abort; `main.ts` only set `comparison` on a `found` result, so `error` and `not-found` both yielded no comparison; the template (`success.md.j2`) keyed off `hasComparison` and rendered the same "no baseline" copy for both. The `/ci/runs/latest` payload is multi-MB, so a brief latency blip exceeds the 10s ceiling.

## Fix

1. **Retry transient failures** in `fetchPreviousRun` — timeout / network / 5xx, with a short backoff (2 retries by default). A genuine **404** (no baseline) and other **4xx** are returned immediately and **never retried**. The `found | not-found | error` union is unchanged.
2. **Stop conflating the two states** — a new `comparisonUnavailable` flag on `ReportContext`, set in `main.ts` on the post-retry `error` path, drives a distinct **"comparison temporarily unavailable — re-run the check"** message in the template instead of the "no baseline / add a push trigger" copy. Even if retries exhaust, the message no longer lies.

The optional payload trim of `/ci/runs/latest` (issue item 3) is **deferred** — it lives in the Site API, tracked separately.

## Acceptance criteria
- ✅ A transient baseline-fetch failure no longer renders the "no baseline" copy — it renders a clearly-transient message (and/or succeeds via retry).
- ✅ A genuine missing baseline still renders the "no baseline / add a push trigger" guidance, and is **not** retried.

## Tests
- `fetchPreviousRun`: retries a timeout then succeeds; retries a 5xx then succeeds; does **not** retry a 404 (1 call → not-found); does **not** retry a non-404 4xx (1 call → error); returns error after exhausting retries.
- Template: renders the transient message (not the no-baseline copy) when `comparisonUnavailable`; renders the no-baseline copy on genuine absence.
- 51/51 affected unit tests pass; `tsc --noEmit` clean. (Full suite's DB-backed integration tests aren't runnable locally — unaffected by these logic-only changes.)