### PR TITLE
feat: render the unset-baseline callout on the PR comment

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -519,6 +519,8 @@ describe("unset-baseline callout (Site #3297 / #3312)", () => {
     });
     const output = renderTemplate(ctx);
 
+    // Rendered as a GFM warning alert.
+    expect(output).toContain("> [!WARNING]");
     expect(output).toContain("No comparison branch configured");
     // Names the fallback branch and the acute head-vs-head consequence...
     expect(output).toContain("`feature-x`");

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -502,3 +502,72 @@ describe("baseline absent vs. temporarily unavailable (Site#3287)", () => {
     expect(output).not.toContain("add a `push` trigger");
   });
 });
+
+describe("unset-baseline callout (Site #3297 / #3312)", () => {
+  const unsetBaseline = {
+    comparisonBranchConfigured: false,
+    resolvedBranch: "feature-x",
+    headVsHead: true,
+    unset: true,
+    mcpCall: 'get_repo_config({ repo: "owner/repo" })',
+  };
+
+  test("warns when the baseline is unset, even though a comparison was produced", () => {
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      runMetadata: makeMetadata({ baseline: unsetBaseline }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("No comparison branch configured");
+    // Names the fallback branch and the acute head-vs-head consequence...
+    expect(output).toContain("`feature-x`");
+    expect(output).toContain("this PR's own branch");
+    expect(output).toContain('0 new');
+    // ...and surfaces the MCP call to inspect/fix it.
+    expect(output).toContain('get_repo_config({ repo: "owner/repo" })');
+  });
+
+  test("frames a base-branch fallback as a divergence/non-PR risk, not head-vs-head", () => {
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      runMetadata: makeMetadata({
+        baseline: { ...unsetBaseline, resolvedBranch: "main", headVsHead: false },
+      }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("No comparison branch configured");
+    expect(output).toContain("`main`");
+    expect(output).toContain("breaks on non-PR runs");
+    expect(output).not.toContain("this PR's own branch");
+  });
+
+  test("renders no callout when a comparison branch is configured", () => {
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      runMetadata: makeMetadata({
+        baseline: {
+          comparisonBranchConfigured: true,
+          resolvedBranch: "staging",
+          headVsHead: false,
+          unset: false,
+          mcpCall: 'get_repo_config({ repo: "owner/repo" })',
+        },
+      }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).not.toContain("No comparison branch configured");
+  });
+
+  test("renders no callout when the baseline state is absent (older API / degraded read)", () => {
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      runMetadata: makeMetadata({ baseline: null }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).not.toContain("No comparison branch configured");
+  });
+});

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -16,6 +16,10 @@
 
 {{ runMetadata.rollupText }}
 {% endif %}
+{% if hasComparison and runMetadata and runMetadata.baseline and runMetadata.baseline.unset %}
+
+> ⚠️ **No comparison branch configured** — regressions and new queries are compared against `{{ runMetadata.baseline.resolvedBranch }}`{% if runMetadata.baseline.headVsHead %}, this PR's own branch, so the counts above can read "0 new" on a PR full of new queries{% else %}, a fallback that can diverge from the dashboard and breaks on non-PR runs{% endif %}. Set a comparison branch (typically your default branch) in the project's CI settings — or inspect it with <code>{{ runMetadata.baseline.mcpCall }}</code>.
+{% endif %}
 
 {% if displayImproved.length > 0 %}
 #### This PR improves queries

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -18,7 +18,8 @@
 {% endif %}
 {% if hasComparison and runMetadata and runMetadata.baseline and runMetadata.baseline.unset %}
 
-> ⚠️ **No comparison branch configured** — regressions and new queries are compared against `{{ runMetadata.baseline.resolvedBranch }}`{% if runMetadata.baseline.headVsHead %}, this PR's own branch, so the counts above can read "0 new" on a PR full of new queries{% else %}, a fallback that can diverge from the dashboard and breaks on non-PR runs{% endif %}. Set a comparison branch (typically your default branch) in the project's CI settings — or inspect it with <code>{{ runMetadata.baseline.mcpCall }}</code>.
+> [!WARNING]
+> **No comparison branch configured** — regressions and new queries are compared against `{{ runMetadata.baseline.resolvedBranch }}`{% if runMetadata.baseline.headVsHead %}, this PR's own branch, so the counts above can read "0 new" on a PR full of new queries{% else %}, a fallback that can diverge from the dashboard and breaks on non-PR runs{% endif %}. Set a comparison branch (typically your default branch) in the project's CI settings — or inspect it with <code>{{ runMetadata.baseline.mcpCall }}</code>.
 {% endif %}
 
 {% if displayImproved.length > 0 %}

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -102,6 +102,23 @@ export interface CiRunMetadata {
   signalKeys: { new: string; regressed: string; improved: string; index: string };
   /** Per-query run-scoped detail links, keyed by query hash. Empty when the repo isn't linked. */
   queries: Array<{ hash: string; link: string }>;
+  /**
+   * Comparison-baseline state (Site #3297). Optional: absent on a Site API that
+   * predates it (deploy skew — render nothing), `null` when the API couldn't
+   * resolve the baseline (a degraded read — unknown, not "unset"). When `unset`
+   * is true the project has no comparison branch configured (or it collapsed to
+   * a head-vs-head comparison), so the counts can be inaccurate (#3292) and the
+   * comment should warn. `resolvedBranch` is what the comparison fell back to;
+   * `headVsHead` is the acute all-zeros case; `mcpCall` is the MCP call to
+   * inspect/fix the config.
+   */
+  baseline?: {
+    comparisonBranchConfigured: boolean;
+    resolvedBranch: string;
+    headVsHead: boolean;
+    unset: boolean;
+    mcpCall: string;
+  } | null;
 }
 
 /**


### PR DESCRIPTION
Renderer half of **Site #3297**. Closes **Site #3312**. Part of the unset-baseline surfacing thread (Site #3292 follow-ups, epic Site #3106).

## Problem

When a project has **no comparison branch configured**, the baseline silently falls back — to head on a re-push, or (since #147) the PR base. So `hasComparison` is **true** and the PR comment renders counts with **no warning**, e.g. `0 regressed · 0 improved · 0 new` on a PR full of new queries (Site #3292, d2armory-next PR #775). The existing "no baseline found / add a `push` trigger" copy only fires when there's *no baseline run at all* — a different condition — so this misconfiguration shipped silently.

## Change

Site now emits `metadata.baseline` on `POST /ci/runs` (Site #3297, merged). This renders it:

- **`site-api.ts`** — type the `baseline` field on `CiRunMetadata` (optional → tolerates an older Site API and a degraded `null` read; both render nothing).
- **`success.md.j2`** — a ⚠️ callout when `hasComparison and runMetadata.baseline.unset`. It names the fallback branch, distinguishes the acute **head-vs-head** case ("`0 new` on a PR full of new queries") from a **base-branch fallback** ("diverges from the dashboard / breaks on non-PR runs"), and surfaces the `get_repo_config` MCP call to inspect/fix it.

Driven off the Site signal (defined once, Site #3302) rather than re-deriving the rule here.

### Scope note
Gated to `hasComparison` — it targets exactly the gap (a comparison *was* produced but the baseline is misconfigured). The no-comparison path keeps its existing "add a push trigger" guidance, so the two messages never stack.

## Tests
`github.test.ts` (+4): unset+head-vs-head renders the callout with branch + `0 new` + MCP call; base-branch fallback frames the divergence/non-PR risk; configured → no callout; absent/`null` baseline → no callout. 55/55 reporter tests pass, existing snapshots unchanged, `tsc --noEmit` clean.

## Cross-repo
Producer: Site #3297 (merged) · shared detection Site #3302 · MCP sibling Site #3298 · dashboard sibling Site #3299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)