### PR TITLE
fix: list new queries in the PR comment, not just count them

### DIFF
--- a/src/reporters/github/__snapshots__/github.test.ts.snap
+++ b/src/reporters/github/__snapshots__/github.test.ts.snap
@@ -17,6 +17,7 @@ exports[`CI-signal metadata parity (analyzer#141) > linked repo: renders rollup 
 
 
 
+
 <sub>Using assumed statistics (10000 rows/table). For better results, <a href="https://docs.querydoctor.com/reference/statistics">sync production stats</a>.</sub>
 
 <sub>More detail → get_ci_run({ runId: "9f3a1c20" }) · <a href="https://app.querydoctor.com/alice/proj/ci/9f3a1c20">view run</a> · <a href="https://docs.querydoctor.com">docs</a></sub>
@@ -36,6 +37,7 @@ exports[`CI-signal metadata parity (analyzer#141) > unlinked repo: rollup + foot
 #### This PR has regressions on queries
 
 - <code>SELECT 1</code><br>cost 120 → 170 (+42%)
+
 
 
 

--- a/src/reporters/github/__snapshots__/github.test.ts.snap
+++ b/src/reporters/github/__snapshots__/github.test.ts.snap
@@ -4,6 +4,7 @@ exports[`CI-signal metadata parity (analyzer#141) > linked repo: renders rollup 
 "### Query Doctor Analysis
 
 28 queries analyzed
+
 2 regressed · 1 improved · 3 new · 0 removed
 
 #### This PR improves queries
@@ -28,6 +29,7 @@ exports[`CI-signal metadata parity (analyzer#141) > unlinked repo: rollup + foot
 "### Query Doctor Analysis
 
 28 queries analyzed
+
 2 regressed · 1 improved · 3 new · 0 removed
 
 #### This PR improves queries

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -184,6 +184,69 @@ describe("buildViewModel", () => {
     expect(vm.newQueryCount).toBe(1);
   });
 
+  test("new query without a recommendation is still listed (Site#3287 follow-up)", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        newQueries: [
+          {
+            hash: "new-covered",
+            query: 'SELECT "id" FROM "matches"',
+            formattedQuery: 'SELECT "id" FROM "matches"',
+            nudges: [], tags: [], tableReferences: [],
+            optimization: { state: "no_improvement_found", cost: 42, indexesUsed: ["matches_pkey"] },
+          },
+        ],
+      }),
+      recommendations: [],
+    });
+    const vm = buildViewModel(ctx);
+    expect(vm.displayNewQueries).toHaveLength(1);
+    expect(vm.displayNewQueries[0].queryPreview).toBe('SELECT "id" FROM "matches"');
+    expect(vm.displayNewQueries[0].costLabel).toBe("cost 42");
+  });
+
+  test("a new query with a recommendation is not double-listed in displayNewQueries", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        newQueries: [
+          {
+            hash: "new-with-rec",
+            query: "SELECT 1",
+            formattedQuery: "SELECT 1",
+            nudges: [], tags: [], tableReferences: [],
+            optimization: { state: "no_improvement_found", cost: 10, indexesUsed: [] },
+          },
+        ],
+      }),
+      recommendations: [makeRecommendation({ fingerprint: "new-with-rec" })],
+    });
+    const vm = buildViewModel(ctx);
+    expect(vm.displayRecommendations.map((r) => r.fingerprint)).toContain(
+      "new-with-rec",
+    );
+    expect(vm.displayNewQueries).toHaveLength(0);
+  });
+
+  test("template lists a new query that has no index suggestion", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        newQueries: [
+          {
+            hash: "new-covered",
+            query: 'SELECT "id" FROM "matches"',
+            formattedQuery: 'SELECT "id" FROM "matches"',
+            nudges: [], tags: [], tableReferences: [],
+            optimization: { state: "no_improvement_found", cost: 42, indexesUsed: ["matches_pkey"] },
+          },
+        ],
+      }),
+    });
+    const output = renderTemplate(ctx);
+    expect(output).toContain("This PR introduces new queries");
+    expect(output).toContain('SELECT "id" FROM "matches"');
+    expect(output).toContain("cost 42 · no index suggestion");
+  });
+
   test("regressions surface in displayRegressed", () => {
     const ctx = makeContext({
       comparison: makeComparison({

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -17,7 +17,7 @@ import {
   Reporter,
 } from "../reporter.ts";
 
-import type { ImprovedQuery, RegressedQuery } from "../site-api.ts";
+import type { CiQueryPayload, ImprovedQuery, RegressedQuery } from "../site-api.ts";
 
 n.configure({ autoescape: false, trimBlocks: true, lstripBlocks: true });
 
@@ -37,6 +37,13 @@ interface DisplayRegression extends RegressedQuery {
 interface DisplayImprovement extends ImprovedQuery {
   queryPreview: string;
   indexesChanged: boolean;
+}
+
+interface DisplayNewQuery {
+  hash: string;
+  queryPreview: string;
+  /** Pre-rendered "cost N" label, or "" when the query has no extractable cost. */
+  costLabel: string;
 }
 
 export function formatCost(cost: number): string {
@@ -90,6 +97,23 @@ function addImprovementPreviews(
   }));
 }
 
+function newQueryCost(q: CiQueryPayload): number | null {
+  if (q.optimization.state === "improvements_available") return q.optimization.cost;
+  if (q.optimization.state === "no_improvement_found") return q.optimization.cost;
+  return null;
+}
+
+function addNewQueryPreviews(newQueries: CiQueryPayload[]): DisplayNewQuery[] {
+  return newQueries.map((q) => {
+    const cost = newQueryCost(q);
+    return {
+      hash: q.hash,
+      queryPreview: queryPreview(q.formattedQuery),
+      costLabel: cost === null ? "" : `cost ${formatCost(cost)}`,
+    };
+  });
+}
+
 /** Per-query detail links keyed by query hash, sourced from the run metadata. */
 function buildQueryLinks(ctx: ReportContext): Record<string, string> {
   const links: Record<string, string> = {};
@@ -109,6 +133,7 @@ export function buildViewModel(ctx: ReportContext) {
       displayRegressed: [] as DisplayRegression[],
       displayAcknowledgedRegressed: [] as DisplayRegression[],
       displayImproved: [] as DisplayImprovement[],
+      displayNewQueries: [] as DisplayNewQuery[],
       preExistingRecommendations: [] as DisplayRecommendation[],
       newQueryCount: 0,
       hasComparison: false,
@@ -119,12 +144,23 @@ export function buildViewModel(ctx: ReportContext) {
   const newQueryHashes = new Set(
     ctx.comparison!.newQueries.map((q) => q.hash),
   );
+  const recommendedHashes = new Set(
+    ctx.recommendations.map((r) => r.fingerprint),
+  );
 
   const displayRecommendations = addPreviews(
     ctx.recommendations.filter((r) => newQueryHashes.has(r.fingerprint)),
   );
   const preExistingRecommendations = addPreviews(
     ctx.recommendations.filter((r) => !newQueryHashes.has(r.fingerprint)),
+  );
+
+  // New queries that carry no index recommendation are otherwise invisible:
+  // counted in the "N new" tally but listed nowhere (Site#3287 follow-up). The
+  // ones that DO have a recommendation already render under "introduces queries
+  // with recommendations", so exclude them here to avoid double-listing.
+  const displayNewQueries = addNewQueryPreviews(
+    ctx.comparison!.newQueries.filter((q) => !recommendedHashes.has(q.hash)),
   );
 
   const displayRegressed = addRegressionPreviews(ctx.comparison!.regressed);
@@ -136,6 +172,7 @@ export function buildViewModel(ctx: ReportContext) {
     displayRegressed,
     displayAcknowledgedRegressed,
     displayImproved,
+    displayNewQueries,
     preExistingRecommendations,
     newQueryCount: ctx.comparison!.newQueries.length,
     hasComparison: true,

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -59,6 +59,15 @@
 {% endfor %}
 {% endif %}
 
+{% if displayNewQueries.length > 0 %}
+#### This PR introduces new queries
+
+{% for q in displayNewQueries %}
+{% set link = queryLinks[q.hash] %}
+- {% if link %}[<code>{{ q.queryPreview }}</code>]({{ link }}){% else %}<code>{{ q.queryPreview }}</code>{% endif %}{% if q.costLabel %}<br>{{ q.costLabel }} · no index suggestion{% endif %}
+{% endfor %}
+{% endif %}
+
 {% if hasComparison and preExistingRecommendations.length > 0 %}
 <details>
 <summary>{{ preExistingRecommendations.length }} pre-existing issue{{ "s" if preExistingRecommendations.length != 1 else "" }}</summary>

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -2,7 +2,6 @@
 
 {% if hasComparison %}
 {{ queryStats.analyzed | default('?') }} queries analyzed
-{%- if newQueryCount > 0 %} | {{ newQueryCount }} new quer{{ "ies" if newQueryCount != 1 else "y" }}{% endif %}
 {% elif comparisonUnavailable %}
 {{ queryStats.analyzed | default('?') }} queries analyzed — comparison temporarily unavailable.
 


### PR DESCRIPTION
Follow-up to the run-page / baseline work (Query-Doctor/Site bug report; epic Query-Doctor/Site#3106).

## Problem

The PR comment header shows e.g. **"74 queries analyzed | 1 new query"** and the roll-up says **"1 new"**, but the body never lists *which* query is new. A new query only appeared in the comment if it carried an index recommendation (under "This PR introduces queries with recommendations"). A new query with **no** recommendation — e.g. an index-covered query that's new but not a problem — was counted in the tally and listed nowhere, making "1 new" unactionable from the PR.

## Fix (analyzer-only)

`compareRuns` already produces `newQueries` with full SQL — the data was there, just never rendered. `buildViewModel` now also returns `displayNewQueries`: the new queries whose hash carries **no** index recommendation (the ones that *do* have a recommendation already render under the recommendations section, so they're excluded here to avoid double-listing). The template gains a **"This PR introduces new queries"** section listing each one's SQL preview, cost, and run link (`cost N · no index suggestion`).

No API change needed: the analyzer already computes the comparison locally whenever it can fetch a baseline. (When no baseline is available there's nothing to attribute — the existing no-baseline / temporarily-unavailable messaging covers that.)

## Tests
- `buildViewModel`: a new query without a recommendation is listed in `displayNewQueries`; a new query *with* a recommendation is not double-listed.
- Template: renders the "This PR introduces new queries" section with the query's SQL and `cost N · no index suggestion`.
- 54/54 affected unit tests pass; `tsc --noEmit` clean. Two golden-file snapshots gained a single blank line — the same empty-section gap every other optional section already emits (GitHub collapses it); verified the snapshot delta is whitespace-only.