### PR TITLE
fix: display rewritten query as the formatted query

### DIFF
--- a/src/sql/recent-query.ts
+++ b/src/sql/recent-query.ts
@@ -135,7 +135,7 @@ export class RecentQuery {
     );
     const analysis = await analyzer.analyze(formattedQuery);
     const query = this.rewriteQuery(analysis.queryWithoutTags);
-    const strippedFormattedQuery = await RecentQuery.formatQuery(analysis.queryWithoutTags);
+    const strippedFormattedQuery = await RecentQuery.formatQuery(query);
     const displayQuery = await RecentQuery.computeDisplayQuery(query);
     return new RecentQuery(
       { ...data, query, formattedQuery: strippedFormattedQuery, displayQuery },


### PR DESCRIPTION
Should fix the problem with queries showing `LIMIT $1` when they're really `LIMIT 50`