### PR TITLE
fix(reporters): keep new-query bullets on separate lines

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -247,6 +247,36 @@ describe("buildViewModel", () => {
     expect(output).toContain("cost 42 · no index suggestion");
   });
 
+  test("renders multiple new queries as separate list items (#158)", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        newQueries: [
+          {
+            hash: "new-sessions",
+            query: 'SELECT "id" FROM "sessions"',
+            formattedQuery: 'SELECT "id" FROM "sessions"',
+            nudges: [], tags: [], tableReferences: [],
+            optimization: { state: "no_improvement_found", cost: 1, indexesUsed: ["sessions_pkey"] },
+          },
+          {
+            hash: "new-item-watches",
+            query: 'SELECT "id" FROM "item_watches"',
+            formattedQuery: 'SELECT "id" FROM "item_watches"',
+            nudges: [], tags: [], tableReferences: [],
+            optimization: { state: "no_improvement_found", cost: 1, indexesUsed: ["item_watches_pkey"] },
+          },
+        ],
+      }),
+    });
+    const output = renderTemplate(ctx);
+    // trimBlocks strips the newline after a trailing block tag, which used to
+    // glue consecutive bullets together (`… no index suggestion- SELECT …`).
+    expect(output).not.toMatch(/no index suggestion-\s*<code>/);
+    expect(output).toContain(
+      'no index suggestion\n- <code>SELECT "id" FROM "item_watches"</code>',
+    );
+  });
+
   test("regressions surface in displayRegressed", () => {
     const ctx = makeContext({
       comparison: makeComparison({

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -83,7 +83,7 @@
 
 {% for q in displayNewQueries %}
 {% set link = queryLinks[q.hash] %}
-- {% if link %}[<code>{{ q.queryPreview }}</code>]({{ link }}){% else %}<code>{{ q.queryPreview }}</code>{% endif %}{% if q.costLabel %}<br>{{ q.costLabel }} · no index suggestion{% endif %}
+- {% if link %}[<code>{{ q.queryPreview }}</code>]({{ link }}){% else %}<code>{{ q.queryPreview }}</code>{% endif %}{% if q.costLabel %}<br>{{ q.costLabel }} · no index suggestion{% endif %}{{""}}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
## Problem

When the PR comment lists more than one entry under **This PR introduces new queries**, the bullets render glued onto one line instead of as a list:

> … cost 1 · no index suggestion**- SELECT** "id", … FROM "item_watches" LIMIT 50;

Seen on https://github.com/veksen/d2armory-next/pull/836.

## Root cause

`github.ts` configures nunjucks with `trimBlocks: true`, which strips the newline immediately after any `%}` block tag. The new-queries loop in `success.md.j2` ended each line on `{% endif %}`, so the newline separating iterations was consumed and consecutive `-` bullets ran together — Markdown then can't parse them as a list.

Every other loop avoids this: most end on literal text, and the **improves queries** loop deliberately ends with `{{""}}` (an output tag, not a block tag) so the newline survives. The new-queries loop was the only one missing that guard.

## Fix

Append `{{""}}` to the end of the new-queries line, matching the improves-queries loop.

## Test

Added a `github.test.ts` case rendering two `displayNewQueries` and asserting the bullets stay on separate lines. Verified it fails on `main` (reproduces `no index suggestion- <code>SELECT …`) and passes with the fix.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)