### PR TITLE
feat: exclude test-origin queries from the CI gate via sqlcommenter tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.10.5",
+        "@query-doctor/core": "^0.10.8",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1187,9 +1187,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.10.6.tgz",
-      "integrity": "sha512-Fr91NFDHUCfGrtEzg8sn6Tq0NNaZcX2cz5FZWFtFFQcdx0yjokRHrATbfAn6D9j8+yhckniOKHqtuKOAb0KO8Q==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.10.8.tgz",
+      "integrity": "sha512-OGgG/06HQRBd60kzm8YfDfOt+SBcY6m1cjmE/fWcoKDxiBbaTepoy0lSA8lYJ/GXtd05zWbW3CBDtOmNEMWAeA==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.10.5",
+    "@query-doctor/core": "^0.10.8",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/reporters/github/__snapshots__/github.test.ts.snap
+++ b/src/reporters/github/__snapshots__/github.test.ts.snap
@@ -19,6 +19,7 @@ exports[`CI-signal metadata parity (analyzer#141) > linked repo: renders rollup 
 
 
 
+
 <sub>Using assumed statistics (10000 rows/table). For better results, <a href="https://docs.querydoctor.com/reference/statistics">sync production stats</a>.</sub>
 
 <sub>More detail → get_ci_run({ runId: "9f3a1c20" }) · <a href="https://app.querydoctor.com/alice/proj/ci/9f3a1c20">view run</a> · <a href="https://docs.querydoctor.com">docs</a></sub>
@@ -39,6 +40,7 @@ exports[`CI-signal metadata parity (analyzer#141) > unlinked repo: rollup + foot
 #### This PR has regressions on queries
 
 - <code>SELECT 1</code><br>cost 120 → 170 (+42%)
+
 
 
 

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -126,6 +126,7 @@ function makeComparison(overrides: Partial<RunComparison> = {}): RunComparison {
     acknowledgedRegressed: [],
     improved: [],
     newQueries: [],
+    testOriginExcluded: [],
     disappearedHashes: [],
     ...overrides,
   };
@@ -182,6 +183,25 @@ describe("buildViewModel", () => {
     expect(vm.displayRecommendations).toHaveLength(1);
     expect(vm.displayRecommendations[0].fingerprint).toBe("new-query-1");
     expect(vm.newQueryCount).toBe(1);
+  });
+
+  test("test-origin excluded queries get their own auditable section (#3199)", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        testOriginExcluded: [
+          {
+            hash: "test-query-1",
+            query: "SELECT * FROM t",
+            formattedQuery: "SELECT * FROM t",
+            nudges: [], tags: [{ key: "file", value: "tests/db.test.ts" }], tableReferences: [],
+            optimization: { state: "no_improvement_found", cost: 99, indexesUsed: [] },
+          },
+        ],
+      }),
+    });
+    const vm = buildViewModel(ctx);
+    expect(vm.displayTestOriginExcluded).toHaveLength(1);
+    expect(vm.displayTestOriginExcluded[0].queryPreview).toBe("SELECT * FROM t");
   });
 
   test("new query without a recommendation is still listed (Site#3287 follow-up)", () => {

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -155,6 +155,7 @@ export function buildViewModel(ctx: ReportContext) {
       displayAcknowledgedRegressed: [] as DisplayRegression[],
       displayImproved: [] as DisplayImprovement[],
       displayNewQueries: [] as DisplayNewQuery[],
+      displayTestOriginExcluded: [] as DisplayNewQuery[],
       preExistingRecommendations: [] as DisplayRecommendation[],
       newQueryCount: 0,
       hasComparison: false,
@@ -190,6 +191,10 @@ export function buildViewModel(ctx: ReportContext) {
   const displayRegressed = addRegressionPreviews(ctx.comparison!.regressed);
   const displayAcknowledgedRegressed = addRegressionPreviews(ctx.comparison!.acknowledgedRegressed);
   const displayImproved = addImprovementPreviews(ctx.comparison!.improved);
+  // Test-origin queries are auto-excluded from the gate (#3199); surface them so
+  // the exclusion is auditable rather than silent. They share the new-query
+  // preview shape (hash + preview + cost label).
+  const displayTestOriginExcluded = addNewQueryPreviews(ctx.comparison!.testOriginExcluded);
 
   return {
     displayRecommendations,
@@ -197,6 +202,7 @@ export function buildViewModel(ctx: ReportContext) {
     displayAcknowledgedRegressed,
     displayImproved,
     displayNewQueries,
+    displayTestOriginExcluded,
     preExistingRecommendations,
     newQueryCount: ctx.comparison!.newQueries.length,
     hasComparison: true,

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -69,6 +69,16 @@
 </details>
 {% endif %}
 
+{% if displayTestOriginExcluded.length > 0 %}
+<details>
+<summary>{{ displayTestOriginExcluded.length }} test-origin quer{{ "ies" if displayTestOriginExcluded.length != 1 else "y" }} excluded from the gate</summary>
+
+{% for q in displayTestOriginExcluded %}
+- <code>{{ q.queryPreview }}</code>{% if q.costLabel %}<br>{{ q.costLabel }}{% endif %}
+{% endfor %}
+</details>
+{% endif %}
+
 {% if displayRecommendations.length > 0 %}
 #### This PR introduces queries with recommendations
 

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -187,6 +187,59 @@ describe("compareRuns", () => {
       expect(result.disappearedHashes).toEqual(["hash-e"]);
     });
   });
+
+  describe("test-origin exclusion (#3199)", () => {
+    const fromTestFile = (q: CiQueryPayload): CiQueryPayload => ({
+      ...q,
+      tags: [{ key: "file", value: "tests/pg/postgres.test.ts" }],
+    });
+
+    test("a regressed test-origin query is bucketed out of the gate, not regressed", () => {
+      const current = [fromTestFile(makeQuery("hash-a", 500))];
+      const previousRun = makePreviousRun([makeQuery("hash-a", 100)]);
+
+      const result = compareRuns(current, previousRun, 10);
+
+      expect(result.regressed).toHaveLength(0);
+      expect(result.testOriginExcluded.map((q) => q.hash)).toEqual(["hash-a"]);
+    });
+
+    test("a new test-origin query never enters newQueries", () => {
+      const current = [fromTestFile(makeQuery("hash-new", 200))];
+      const previousRun = makePreviousRun([]);
+
+      const result = compareRuns(current, previousRun, 10);
+
+      expect(result.newQueries).toHaveLength(0);
+      expect(result.testOriginExcluded.map((q) => q.hash)).toEqual(["hash-new"]);
+    });
+
+    test("production queries in the same run are unaffected", () => {
+      const current = [
+        fromTestFile(makeQuery("hash-test", 500)), // was 100 → excluded
+        makeQuery("hash-prod", 500),               // was 100 → regressed
+      ];
+      const previousRun = makePreviousRun([
+        makeQuery("hash-test", 100),
+        makeQuery("hash-prod", 100),
+      ]);
+
+      const result = compareRuns(current, previousRun, 10);
+
+      expect(result.regressed.map((q) => q.hash)).toEqual(["hash-prod"]);
+      expect(result.testOriginExcluded.map((q) => q.hash)).toEqual(["hash-test"]);
+    });
+
+    test("an untagged query still gates exactly as before", () => {
+      const current = [makeQuery("hash-a", 500)];
+      const previousRun = makePreviousRun([makeQuery("hash-a", 100)]);
+
+      const result = compareRuns(current, previousRun, 10);
+
+      expect(result.regressed).toHaveLength(1);
+      expect(result.testOriginExcluded).toHaveLength(0);
+    });
+  });
 });
 
 describe("postToSiteApi authentication", () => {

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -1,4 +1,5 @@
 import * as github from "@actions/github";
+import { isTestOriginQuery } from "@query-doctor/core";
 import type { ComputedStats, FullSchema, IndexRecommendation, Nudge, SQLCommenterTag, StatisticsMode, TableReference } from "@query-doctor/core";
 import { DEFAULT_CONFIG, type AnalyzerConfig } from "../config.ts";
 import type { OptimizedQuery } from "../sql/recent-query.ts";
@@ -198,6 +199,14 @@ export interface RunComparison {
   acknowledgedRegressed: RegressedQuery[];
   improved: ImprovedQuery[];
   newQueries: CiQueryPayload[];
+  /**
+   * Queries bucketed out of the gate because they originate from a test file
+   * (Query-Doctor/Site#3199). Kept as a distinct list — not silently dropped —
+   * so the run stays auditable: the PR comment can show what was excluded, and
+   * they never appear in `regressed`/`newQueries`/`improved`, so the gate can't
+   * fail on them.
+   */
+  testOriginExcluded: CiQueryPayload[];
   disappearedHashes: string[];
 }
 
@@ -296,8 +305,17 @@ export function compareRuns(
   const acknowledgedRegressed: RegressedQuery[] = [];
   const improved: ImprovedQuery[] = [];
   const newQueries: CiQueryPayload[] = [];
+  const testOriginExcluded: CiQueryPayload[] = [];
 
   for (const current of currentQueries) {
+    // A query issued from a test file runs no production path, so it must never
+    // gate the PR (#3199). Bucket it out before any regressed/new/improved
+    // categorization — same rule the Site alert engine applies, via the shared
+    // detector in @query-doctor/core — so the two surfaces can't drift.
+    if (isTestOriginQuery(current.tags)) {
+      testOriginExcluded.push(current);
+      continue;
+    }
     const prev = prevByHash.get(current.hash);
     if (!prev) {
       newQueries.push(current);
@@ -359,6 +377,7 @@ export function compareRuns(
     acknowledgedRegressed,
     improved,
     newQueries,
+    testOriginExcluded,
     disappearedHashes,
   };
 }


### PR DESCRIPTION
Completes the analyzer half of **Query-Doctor/Site#3199**. Pairs with Site PR #3462 (server/alert-engine half, merged) and Site #3465 (published `@query-doctor/core@0.10.8`, merged).

## Problem

A query issued from a **test file** — e.g. a read-back assertion in `tests/pg/postgres.test.ts` — runs no production path, but the gate flagged it as a regression and it had to be **ignored one hash at a time** (Site#3193 / Nutcracker PR #484).

## What changed

- **`compareRuns` (`src/reporters/site-api.ts`)**: any query whose sqlcommenter `file` tag marks it test-origin is bucketed into a new **`testOriginExcluded`** list *before* regressed/new/improved categorization. So it never enters `regressed` or `newQueries` — the two lists `main.ts` gates on — and the PR can't fail on it. Kept as a distinct list, **not silently dropped** (Site#3199 requires this).
- **PR comment (`github.ts` + `success.md.j2`)**: renders the bucket as a collapsible **"N test-origin queries excluded from the gate"**, mirroring the existing "acknowledged regressions (not blocking)" section — so the exclusion is **auditable**.
- **Detection**: `isTestOriginQuery` from `@query-doctor/core` (bumped `^0.10.5` → `^0.10.8`). The **same shared detector** the Site alert engine uses, so the gate and the alert surface apply one rule and can't drift.

Queries with no `file` tag are never test-origin → **behavior unchanged** for untagged codebases.

## Tests

- `site-api.test.ts` — regressed/new test-origin queries land in `testOriginExcluded` not `regressed`/`newQueries`; a production query in the same run still gates; untagged queries gate exactly as before.
- `github.test.ts` — the excluded bucket surfaces in the view model. Snapshots updated: only diff is one blank line per snapshot (an empty optional section, consistent with existing improved/regressed/acknowledged sections).

Full suite: **255 passing**, typecheck clean, build OK.

## Sequencing

`@query-doctor/core@0.10.8` is already published, so this is green on its own — no further prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)