### PR TITLE
fix: surface CI ingest failures in the PR comment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,6 +138,13 @@ async function runInCI(
         if (kind === "auth") {
           // The user's to fix and means CI isn't actually running — fail loudly.
           core.setFailed(`${base} The project TOKEN is missing or invalid.`);
+        } else if (kind === "too_large") {
+          // The payload exceeded the API's size limit — our side to fix, not
+          // theirs, and re-running the same payload won't help. Loud but
+          // non-blocking unless opted in, same as a rejected run.
+          const msg = `${base} The submission was too large for the API to accept; re-running won't help.`;
+          if (env.FAIL_ON_INGEST_ERROR) core.setFailed(msg);
+          else core.error(msg);
         } else if (kind === "rejected") {
           // The API refused a computed run (likely analyzer/API skew) — our bug,
           // not theirs. Red and loud, but don't block the PR unless opted in.

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -485,6 +485,22 @@ describe("template rendering", () => {
     expect(output).toContain("re-run the check to retry");
   });
 
+  test("renders payload-too-large copy for a too_large ingest failure", () => {
+    const ctx = makeContext({
+      ingestError: {
+        kind: "too_large",
+        status: 413,
+        message: '{"statusCode":413,"message":"request entity too large"}',
+      },
+    });
+    const output = renderTemplate(ctx);
+    expect(output).toContain("The submission was too large");
+    expect(output).toContain("HTTP 413");
+    expect(output).toContain("size limit on our side");
+    expect(output).not.toContain("out of sync");
+    expect(output).toContain("request entity too large");
+  });
+
   test("omits the failure banner when ingestion succeeded", () => {
     const ctx = makeContext({
       queryStats: { analyzed: 3, matched: 1, optimized: 0, errored: 0 },

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -6,6 +6,8 @@
 > **Query Doctor couldn't record this run — authentication failed{% if ingestError.status %} (HTTP {{ ingestError.status }}){% endif %}.** The project token is missing or invalid, so nothing was saved to the dashboard. Set a valid `TOKEN` in your workflow.
 {% elif ingestError.kind == "transient" %}
 > **Query Doctor couldn't record this run.** The API was unreachable{% if ingestError.status %} (HTTP {{ ingestError.status }}){% endif %}, so it wasn't saved this time. This is usually temporary — re-run the check to retry.
+{% elif ingestError.kind == "too_large" %}
+> **Query Doctor couldn't record this run.** The submission was too large{% if ingestError.status %} (HTTP {{ ingestError.status }}){% endif %} for the API to accept, so it wasn't saved to the dashboard and the results below may be incomplete. Re-running won't help — this is a size limit on our side.
 {% else %}
 > **Query Doctor couldn't record this run.** The API rejected the submission{% if ingestError.status %} (HTTP {{ ingestError.status }}){% endif %}, so it wasn't saved to the dashboard and the results below may be incomplete. This usually means the analyzer and Query Doctor are out of sync — re-running won't help; if it persists, it's a bug on our side.
 {% endif %}

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -97,7 +97,8 @@ export interface ReportContext {
   /**
    * `POST /ci/runs` failed, so the run wasn't saved to the dashboard. Drives a
    * prominent failure banner in the comment so the run doesn't silently vanish;
-   * `kind` tailors the copy (transient → retry, auth → fix token, rejected → our bug).
+   * `kind` tailors the copy (transient → retry, auth → fix token, too_large →
+   * payload over the size limit, rejected → our bug).
    */
   ingestError?: {
     kind: IngestFailureKind;

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -334,6 +334,10 @@ describe("classifyIngestFailure", () => {
     expect(classifyIngestFailure(403)).toBe("auth");
   });
 
+  test("treats 413 as too_large (payload over the size limit)", () => {
+    expect(classifyIngestFailure(413)).toBe("too_large");
+  });
+
   test("treats other 4xx as a rejected run (contract skew)", () => {
     expect(classifyIngestFailure(400)).toBe("rejected");
     expect(classifyIngestFailure(422)).toBe("rejected");

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -169,14 +169,18 @@ export type PostRunOutcome =
  * How a rejected ingest should be treated, by recipient and recoverability:
  * - `transient`: network/timeout/5xx — recoverable, re-run to retry.
  * - `auth`: 401/403 — CI is misconfigured; the user must fix the token.
+ * - `too_large`: 413 — the payload exceeded the API's size limit. A distinct
+ *   cause from `rejected`: it's not contract skew, so the "out of sync" copy
+ *   would be wrong. Re-running the same payload won't help.
  * - `rejected`: other 4xx — the API refused a computed run (e.g. analyzer/API
  *   contract skew); not the user's to fix and re-running won't help.
  */
-export type IngestFailureKind = "transient" | "auth" | "rejected";
+export type IngestFailureKind = "transient" | "auth" | "too_large" | "rejected";
 
 export function classifyIngestFailure(status: number | null): IngestFailureKind {
   if (status === null || status >= 500) return "transient";
   if (status === 401 || status === 403) return "auth";
+  if (status === 413) return "too_large";
   return "rejected";
 }
 


### PR DESCRIPTION
When `POST /ci/runs` fails, the run is computed but never saved — previously that produced a degraded PR comment that looked like a normal empty result plus a green check, so the failure silently vanished. This branch surfaces the failure prominently and tailors both the comment copy and the Actions severity to the cause:

- **`auth` (401/403)** — the project token is missing/invalid; CI isn't really running. Fails loudly (`setFailed`).
- **`transient` (network/timeout/5xx)** — recoverable; warns and suggests a re-run.
- **`too_large` (413)** — the payload exceeded the API's size limit. Distinct from `rejected`: it's a size issue, not contract skew, so the "out of sync" copy would be wrong. Re-running won't help.
- **`rejected` (other 4xx)** — the API refused a computed run (likely analyzer/API contract skew); our bug, non-blocking unless `FAIL_ON_INGEST_ERROR`.

The raw error body is echoed (truncated) into a Details block in the comment. Tests cover the classifier and each rendered banner.

Pairs with Query-Doctor/Site #3488 (raise the ingest body limit to 10mb) and #3489 (return a typed `payload_too_large` 413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)