### PR TITLE
chore: bump @query-doctor/core to ^0.10.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.10.8",
+        "@query-doctor/core": "^0.10.10",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1187,9 +1187,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.10.8.tgz",
-      "integrity": "sha512-OGgG/06HQRBd60kzm8YfDfOt+SBcY6m1cjmE/fWcoKDxiBbaTepoy0lSA8lYJ/GXtd05zWbW3CBDtOmNEMWAeA==",
+      "version": "0.10.10",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.10.10.tgz",
+      "integrity": "sha512-RCQT/c6GpN1d/8a4+CFJ6qOIqfXZ3eQLEBp9xCCuVk0fMOWsCjxLaGkNLug3OB9V24VVJarmM5Alm7D/IRRuaA==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.10.8",
+    "@query-doctor/core": "^0.10.10",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/sync/schema_differ.test.ts
+++ b/src/sync/schema_differ.test.ts
@@ -135,7 +135,12 @@ test("put tracks schemas per connectable independently", () => {
 
   const updated = makeSchema({
     extensions: [
-      { extensionName: "pg_trgm", version: "1.0", schemaName: "public" as any },
+      {
+        type: "extension",
+        extensionName: "pg_trgm",
+        version: "1.0",
+        schemaName: "public" as any,
+      },
     ],
   });
 


### PR DESCRIPTION
Bumps `@query-doctor/core` from `^0.10.8` to `^0.10.10` (lockfile `0.10.8` → `0.10.10`) to pick up the extension/trigger `type` discriminator fix (Query-Doctor/Site#3487).

**Why it matters:** the old core stripped `type` off extensions when parsing the schema dump, so any CI run whose schema includes an extension (e.g. `pg_stat_statements`) was rejected by the Site API with HTTP 400 and rendered the "analyzer and Query Doctor are out of sync" caution. That fix is merged and published, but the deployed analyzer still bundled `0.10.8` — so the 400s continued until this bump. Updates the one `schema_differ` test fixture that built an extension without the now-required `type`. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)