### PR TITLE
chore(deps): adopt @query-doctor/core ^0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.10.10",
+        "@query-doctor/core": "^0.11.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1187,9 +1187,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.10.10.tgz",
-      "integrity": "sha512-RCQT/c6GpN1d/8a4+CFJ6qOIqfXZ3eQLEBp9xCCuVk0fMOWsCjxLaGkNLug3OB9V24VVJarmM5Alm7D/IRRuaA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-gNYZovkc2vfU5ff7+OV9w+yo3jbIvltjCL7kkyQY2PD6UbyCmr5YJXx0GITVZ7KnRKfWsvQryfHvFGQ30lWqig==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.10.10",
+    "@query-doctor/core": "^0.11.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
## What
Bumps `@query-doctor/core` `^0.10.10 → ^0.11.0` to pick up the exports shipped in core 0.11.0: verdict contract, failure taxonomy, policy engine (Query-Doctor/Site#3497 / #3498 / #3500).

## Status
- ✅ **core 0.11.0 is published** to npm (Query-Doctor/Site#3519 merged).
- ✅ `package-lock.json` synced to resolve core 0.11.0.
- ✅ Rebased on latest `origin/main`; CI green on head.

Two-line change (`package.json` + `package-lock.json`); no source changes. Ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)