### PR TITLE
chore(deps): adopt @query-doctor/core ^0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.11.0",
+        "@query-doctor/core": "^0.12.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1187,9 +1187,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-gNYZovkc2vfU5ff7+OV9w+yo3jbIvltjCL7kkyQY2PD6UbyCmr5YJXx0GITVZ7KnRKfWsvQryfHvFGQ30lWqig==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-z2uCIHuHKjcqYTDWW5s13K0iUfBIN5mYZsTNHYzO7FwYuglshWEpsq2bLLLiegL1eqzYK+Et6QF7qy/Vs0TUBw==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.11.0",
+    "@query-doctor/core": "^0.12.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
Adopts core 0.12.0 (live on npm): the verdict reference renderer now presents the fix path and the triage exit as one either-or choice, and the contract documents the terse copy rule (Query-Doctor/Site ADR-0003). Groundwork for Query-Doctor/Site#3537 (thin handoff comment) and Query-Doctor/Site#3541 (untested-data-access fails the check).

Full analyzer suite green against 0.12.0: 28 files, 282 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)