### PR TITLE
feat(gate): capture overrides the test-presence diff heuristic (#3502)

### DIFF
--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -214,4 +214,27 @@ describe("evaluateTestPresence", () => {
     expect(verdict?.reason).toContain("flagged conservatively");
     expect(verdict?.nextStep).toContain("test");
   });
+
+  // A repo whose data-layer test doesn't sit beside the source or share its stem
+  // (e.g. `tests/pg/postgres.test.ts` for `src/db/postgres.ts`) trips the diff
+  // heuristic — but the run captured the new queries, proving a test ran them.
+  test("passes when capture reports new queries the run executed", () => {
+    const files = [
+      changed("src/db/postgres.ts", "return db.select().from(projects).where(eq(projects.userId, id));"),
+    ];
+    expect(evaluateTestPresence(files)).not.toBeNull();
+    const verdict = evaluateTestPresence(files, undefined, {
+      newQueryHashes: ["f13683ee48e6a487", "53350021ed44ae14"],
+    });
+    expect(verdict).toBeNull();
+  });
+
+  test("still flags when capture reports no new queries", () => {
+    const verdict = evaluateTestPresence(
+      [changed("src/db/postgres.ts", "return db.select().from(projects);")],
+      undefined,
+      { newQueryHashes: [] },
+    );
+    expect(verdict?.dataAccessFiles).toEqual(["src/db/postgres.ts"]);
+  });
 });

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -261,13 +261,25 @@ const TRIAGE_HINT =
   "exception is auditable rather than silent.";
 
 /**
+ * Capture evidence from the run, used to override the diff heuristic with what
+ * actually executed. `newQueryHashes` are the fingerprints this run captured
+ * that the baseline had not — query surface this PR introduced that a real-DB
+ * test ran against Postgres. Empty when there is no baseline to diff against.
+ */
+export interface TestPresenceCapture {
+  newQueryHashes: readonly string[];
+}
+
+/**
  * Evaluate the gate. Returns a verdict listing the changed data-access files
  * that have no related data-layer test, or `null` when the PR passes — no query
- * change, or every query change has a related test alongside it.
+ * change, every query change has a related test alongside it, or capture proves
+ * the change ran against Postgres.
  */
 export function evaluateTestPresence(
   files: ChangedFile[],
   config: TestPresenceConfig = DEFAULT_TEST_PRESENCE_CONFIG,
+  capture?: TestPresenceCapture,
 ): TestPresenceVerdict | null {
   const { dataAccessChanged, dataLayerTestChanged } = classifyChangedFiles(
     files,
@@ -277,6 +289,17 @@ export function evaluateTestPresence(
     (path) => !dataLayerTestChanged.some((test) => isRelated(path, test)),
   );
   if (untested.length === 0) return null;
+
+  // Capture is ground truth for the blind spot this gate exists to catch: a
+  // query change that runs against Postgres in no test produces no captured
+  // query. If this run captured new query surface, a real-DB test *did* exercise
+  // the change — observed execution overrides the diff heuristic's "no related
+  // test" guess, so don't flag. Per-query→file attribution (which would let a
+  // partially-tested PR still flag its one uncovered file) is the next rung,
+  // #3503; until then this suppresses at the run level, on the safe under-fire
+  // side the gate already favours.
+  if (capture && capture.newQueryHashes.length > 0) return null;
+
   return {
     condition: "untested-data-access",
     verdictClass: "uncertain-conservative-flag",

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,16 +211,21 @@ async function runInCI(
       );
     }
 
-    // Crude test-presence gate (#3496): flag data-access changes that ship with
-    // no data-layer test. A pure diff heuristic — independent of capture and of
-    // the baseline comparison, so it runs even on a brand-new PR with no
-    // baseline. Best-effort: a GitHub API hiccup must never sink the whole run.
+    // Test-presence gate (#3496): flag data-access changes that ship with no
+    // data-layer test. A diff heuristic, but capture overrides it (#3502): when
+    // the run captured new query surface, the change demonstrably ran against
+    // Postgres, so the "no related test" guess is dropped. Runs even on a
+    // brand-new PR with no baseline (then capture is empty and it's diff-only).
+    // Best-effort: a GitHub API hiccup must never sink the whole run.
     if (env.GITHUB_TOKEN) {
       try {
         const changedFiles = await fetchPrChangedFiles(env.GITHUB_TOKEN);
         if (changedFiles) {
+          const capture = reportContext.comparison
+            ? { newQueryHashes: reportContext.comparison.newQueries.map((q) => q.hash) }
+            : undefined;
           reportContext.testPresenceVerdict =
-            evaluateTestPresence(changedFiles) ?? undefined;
+            evaluateTestPresence(changedFiles, undefined, capture) ?? undefined;
         }
       } catch (err) {
         log.warn(`Test-presence gate skipped: ${err}`, "main");


### PR DESCRIPTION
## What

The test-presence gate (`evaluateTestPresence`) is a pure **diff heuristic** — it flags a data-access change when no *related* data-layer test changed alongside it, matching "related" by directory or filename stem. That misfires when a repo's test doesn't mirror the source path, even though a real-DB test covers the change.

This teaches the gate to prefer **capture** over the guess: when the run captured new query surface, a real-DB test demonstrably executed the change against Postgres, so the flag is dropped.

## Why

Capture is ground truth for the exact blind spot this gate exists to catch: a query that runs against Postgres in no test produces no captured query. If QD captured new queries, the diff heuristic's "no related test" conclusion is contradicted by observed execution.

### Concrete case — Nutcracker [#749](https://github.com/ChrisHarris2012/Nutcracker/pull/749)

- The PR adds `findByUser` to `src/db/postgres.ts` and a real-DB test in `tests/pg/postgres.test.ts`.
- The gate fired "no related data-layer test": `tests/**pg**/postgres.test.ts` doesn't share a directory or stem with `src/**db**/postgres.ts`, so `isRelated` missed it.
- Meanwhile QD captured **2 new queries** in the same run (the `LIMIT 50` shape — straight from the test's `findByUser(u, 50)`, not the route's 100/500) and listed them in the very same comment that claimed nothing exercises them.

With this change, `newQueryHashes.length > 0` → the verdict is `null` → the warning never posts.

## How

- `evaluateTestPresence(files, config, capture?)` gains an optional `capture` with `newQueryHashes`. Non-empty → return `null`.
- `main.ts` feeds `comparison.newQueries` hashes into the gate (already computed before the gate runs).

## Limitation (next rung, #3503)

Suppression is **run-level**: a PR that tests file A but ships an untested query in file B is fully cleared for now. Per-query→file attribution is #3503. This errs on the under-fire side the gate already favours (warn-only).

## Tests

- New: capture with new-query hashes clears the flag (the #749 shape); empty capture still flags. Full gate suite green (24), typecheck clean.