### PR TITLE
fix(reporter): stop test-origin bullets gluing onto the cost line

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -204,6 +204,29 @@ describe("buildViewModel", () => {
     expect(vm.displayTestOriginExcluded[0].queryPreview).toBe("SELECT * FROM t");
   });
 
+  test("multiple test-origin excluded queries each start a new bullet (trimBlocks glue)", () => {
+    // trimBlocks eats the newline after the row's trailing `{% endif %}`; without
+    // the `{{""}}` guard the next bullet glues onto the prior cost line ("cost 1- SELECT…").
+    const excluded = (hash: string, table: string) => ({
+      hash,
+      query: `SELECT "id" FROM "${table}"`,
+      formattedQuery: `SELECT "id" FROM "${table}"`,
+      nudges: [], tags: [], tableReferences: [],
+      optimization: { state: "no_improvement_found" as const, cost: 1, indexesUsed: [] },
+    });
+    const ctx = makeContext({
+      comparison: makeComparison({
+        testOriginExcluded: [excluded("t1", "sessions"), excluded("t2", "item_watches")],
+      }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).not.toMatch(/cost 1- /);
+    expect(output).toContain(
+      '<code>SELECT "id" FROM "sessions"</code><br>cost 1\n- <code>SELECT "id" FROM "item_watches"</code>',
+    );
+  });
+
   test("new query without a recommendation is still listed (Site#3287 follow-up)", () => {
     const ctx = makeContext({
       comparison: makeComparison({

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -91,7 +91,7 @@
 <summary>{{ displayTestOriginExcluded.length }} test-origin quer{{ "ies" if displayTestOriginExcluded.length != 1 else "y" }} excluded from the gate</summary>
 
 {% for q in displayTestOriginExcluded %}
-- <code>{{ q.queryPreview }}</code>{% if q.costLabel %}<br>{{ q.costLabel }}{% endif %}
+- <code>{{ q.queryPreview }}</code>{% if q.costLabel %}<br>{{ q.costLabel }}{% endif %}{{""}}
 {% endfor %}
 </details>
 {% endif %}


### PR DESCRIPTION
## What

In the CI PR comment, the **test-origin queries excluded from the gate** list rendered the second query on the same line as the first query's `cost` label:

```
SELECT "id", ... FROM "sessions" LIMIT 50;
cost 1- SELECT "id", ... FROM "item_watches" LIMIT 50;
cost 1
```

## Why

The template engine is configured with `trimBlocks: true` (`github.ts`), which strips the newline immediately after a block tag. The test-origin row ended with a trailing `{% endif %}`, so that newline got eaten and the next `- ` bullet glued onto the previous item's cost line. Every other row in this template already guards against this by appending `{{""}}` after the trailing `{% endif %}` — this section was the only one missing it.

## Fix

Append the same `{{""}}` guard so the block tag is no longer the last token on the line and the newline survives.

## Test

Added a regression test that renders two excluded queries and asserts each starts its own bullet. Verified it fails without the fix (reproduces `cost 1- <code>…`) and passes with it.