### PR TITLE
revert: keep pushing non-DML statements (reverts #179)

### DIFF
--- a/src/remote/api-client.ts
+++ b/src/remote/api-client.ts
@@ -33,24 +33,12 @@ export function hookUpApiReporter(api: RpcStub<ServerApi>, remote: Remote): () =
       log.error(`Failed to push stats: ${err}`, "api-client");
     });
   };
-  // pg_stat_statements retains everything the database ever executed — COPY
-  // from dumps/seeds, DDL from migrations, VACUUM. None of it is an app query:
-  // shipping it pollutes the project's query catalog and fires unfixable
-  // "no CI coverage" alerts (Query-Doctor/Site#3578). Only DML is pushed.
-  // `undefined` (analysis skipped or failed) is pushed too — fail open rather
-  // than silently losing real queries. Known gap: core classifies MergeStmt as
-  // "other", so MERGE statements are dropped until its map learns them.
-  const isAppQuery = (query: RecentQuery) => query.statementType !== "other";
-
   const onQueriesPolled = (queries: RecentQuery[]) => {
-    const appQueries = queries.filter(isAppQuery);
-    if (appQueries.length === 0) return;
-    api.pushQuery(JSON.parse(JSON.stringify(appQueries))).catch((err) => {
+    api.pushQuery(JSON.parse(JSON.stringify(queries))).catch((err) => {
       log.error(`Failed to push polled queries: ${err}`, "api-client");
     });
   };
   const pushOptimizedQuery = (query: OptimizedQuery) => {
-    if (!isAppQuery(query)) return;
     const q = [query.toJSON()]
     api.pushQuery(q).catch((err) => {
       log.error(`Failed to push optimized query: ${err}`, "api-client");

--- a/src/sql/recent-query.test.ts
+++ b/src/sql/recent-query.test.ts
@@ -259,38 +259,6 @@ test("analyze sets isSelectQuery=false for DELETE with EXISTS subquery", async (
   expect(rq.isSelectQuery).toBe(false);
 });
 
-// --- statementType persistence (push sites drop "other" — see api-client) ---
-
-test("analyze keeps statementType on the instance for DML", async () => {
-  const data = makeRawQuery({ query: "SELECT * FROM users" });
-  const rq = await RecentQuery.analyze(data, testHash, testNormalizedHash);
-  expect(rq.statementType).toBe("select");
-});
-
-test("analyze classifies DDL as other", async () => {
-  const data = makeRawQuery({
-    query:
-      'CREATE INDEX "ci_runs_repo_created_at_idx" ON "ci_runs" USING btree ("repo", "created_at" DESC)',
-  });
-  const rq = await RecentQuery.analyze(data, testHash, testNormalizedHash);
-  expect(rq.statementType).toBe("other");
-});
-
-test("analyze classifies COPY as other", async () => {
-  const data = makeRawQuery({
-    query: "COPY public.project_queries (id, hash) FROM stdin",
-  });
-  const rq = await RecentQuery.analyze(data, testHash, testNormalizedHash);
-  expect(rq.statementType).toBe("other");
-});
-
-test("oversized queries skip analysis and carry no statementType", async () => {
-  const data = makeRawQuery({ query: `SELECT ${"1,".repeat(30_000)} 1` });
-  const rq = await RecentQuery.analyze(data, testHash, testNormalizedHash);
-  expect(rq.analysisSkipped).toBe(true);
-  expect(rq.statementType).toBeUndefined();
-});
-
 // --- displayQuery via analyze ---
 
 test("analyze populates displayQuery for wide SELECTs", async () => {

--- a/src/sql/recent-query.ts
+++ b/src/sql/recent-query.ts
@@ -49,9 +49,7 @@ export class RecentQuery {
     readonly hash: QueryHash,
     readonly normalizedHash: QueryHash,
     analysisSkipped = false,
-    // Kept on the instance so push sites can drop non-DML (see api-client);
-    // undefined when analysis was skipped (oversized) or failed.
-    readonly statementType?: StatementType,
+    statementType?: StatementType,
   ) {
     this.username = data.username;
     this.query = data.query;


### PR DESCRIPTION
Reverts #179 (`80af5fb`).

### Goal

Stop dropping non-DML events at the capture layer. #179 quieted the migration-day alert spam (Query-Doctor/Site#3578) by filtering `statementType === "other"` at both push sites, so `CREATE`/`DROP`/`ALTER`/`COPY`/`VACUUM` never left the analyzer. That fixes the noise but discards the events before QD ever ingests them — which permanently removes downstream optionality: an index dropped in prod, a schema-changing migration, correlating a later CI regression against a schema change, an MCP "recent events" feed. None of that is possible once the event is dropped at capture.

Suppressing the alert does not require dropping the data. That's an alerting-layer decision (scope + cadence), so ingestion should stay complete and the noise handled where alerts are decided — tracked in Query-Doctor/Site#3581.

### What

- Before (on `main`): only DML is pushed; DDL/COPY/VACUUM are filtered out and never reach the catalog or the dashboard.
- After (this PR): every statement sampled from pg_stat_statements is pushed again, restoring the pre-#179 behavior.

Accepted trade-off: the migration-day alert spam returns until the alerting-side handling lands. That's deliberate — the fix belongs there, not here.

### How

Plain `git revert` of the squash commit. Restores the two push sites in `src/remote/api-client.ts` to push unconditionally and drops the `statementType` instance field re-added to `RecentQuery`.

### Tests

`npm run typecheck` clean; full suite passes (306/306 — the 4 removed cases are the assertions #179 added for the dropped filter; one Docker-teardown flake under the parallel run passes 3/3 in isolation).