### PR TITLE
fix(gate): block untested-data-access via the shared policy engine

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,18 @@
+import type { RepoPolicyConfig } from "@query-doctor/core";
+
 export interface AnalyzerConfig {
   minimumCost: number;
   regressionThreshold: number;
   ignoredQueryHashes: string[];
   acknowledgedQueryHashes: string[];
   comparisonBranch?: string;
+  /**
+   * Per-condition CI policy overrides (#3500): condition key → `fail | warn | off`.
+   * Absent keys fall back to core's safe defaults, so `untested-data-access` blocks
+   * unless a repo softens it. Optional and empty until the Site repo config plumbs
+   * it through `getRepoConfig`; the gate honours it the moment it arrives.
+   */
+  conditionPolicies?: RepoPolicyConfig;
 }
 
 export const DEFAULT_CONFIG: AnalyzerConfig = {

--- a/src/gate/policy.test.ts
+++ b/src/gate/policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveVerdict } from "./policy.ts";
+
+const untested = {
+  condition: "untested-data-access",
+  verdictClass: "uncertain-conservative-flag" as const,
+};
+
+describe("resolveVerdict", () => {
+  it("blocks an unverified data-access change by default", () => {
+    expect(resolveVerdict(untested)).toEqual({
+      policy: "fail",
+      conclusion: "failure",
+      surfaced: true,
+    });
+  });
+
+  it("softens to a surfaced, non-blocking neutral under a warn policy", () => {
+    expect(
+      resolveVerdict(untested, { "untested-data-access": "warn" }),
+    ).toEqual({
+      policy: "warn",
+      conclusion: "neutral",
+      surfaced: true,
+    });
+  });
+
+  it("suppresses the condition entirely under an off policy", () => {
+    expect(
+      resolveVerdict(untested, { "untested-data-access": "off" }),
+    ).toEqual({
+      policy: "off",
+      conclusion: "success",
+      surfaced: false,
+    });
+  });
+
+  it("keeps a passing verdict green even under a fail policy — the taxonomy drives the conclusion", () => {
+    expect(
+      resolveVerdict(
+        { condition: "untested-data-access", verdictClass: "pass" },
+        { "untested-data-access": "fail" },
+      ),
+    ).toEqual({
+      policy: "fail",
+      conclusion: "success",
+      surfaced: true,
+    });
+  });
+});

--- a/src/gate/policy.ts
+++ b/src/gate/policy.ts
@@ -1,0 +1,47 @@
+// Resolve a gate verdict to the CI conclusion it produces, using the shared
+// failure taxonomy (#3498) and policy engine (#3500) from @query-doctor/core
+// rather than a severity the analyzer decides for itself.
+//
+// The taxonomy fixes what a verdict class concludes: `uncertain-conservative-flag`
+// concludes `failure`, so a data-access change Query Doctor could not verify
+// blocks the check by default — an unverified result gates, framed as "could not
+// check this, flagging to be safe", never as "your query is broken". The per-repo
+// policy then decides whether this repo lets that condition fail (`fail`), softens
+// it to a surfaced-but-non-blocking neutral (`warn`), or suppresses it (`off`).
+
+import {
+  conclusionForVerdict,
+  policyFor,
+  type CiConclusion,
+  type ConditionPolicy,
+  type RepoPolicyConfig,
+  type VerdictClass,
+} from "@query-doctor/core";
+
+export interface ResolvedVerdict {
+  /** The effective per-repo policy for the condition. */
+  policy: ConditionPolicy;
+  /** CI conclusion after policy: `failure` blocks the check, `neutral`/`success` don't. */
+  conclusion: CiConclusion;
+  /** False only when the policy is `off` — the condition is suppressed, not surfaced anywhere. */
+  surfaced: boolean;
+}
+
+/**
+ * Resolve a verdict's effective conclusion. `off` is reported as unsurfaced (the
+ * caller drops the condition — no comment block, no check annotation); every other
+ * policy surfaces it, with `warn` capping a taxonomy failure at a non-blocking
+ * neutral. The cap mirrors core's policy.ts `applyPolicy`, which core keeps private.
+ */
+export function resolveVerdict(
+  verdict: { condition: string; verdictClass: VerdictClass },
+  config: RepoPolicyConfig = {},
+): ResolvedVerdict {
+  const policy = policyFor(verdict.condition, config);
+  if (policy === "off") {
+    return { policy, conclusion: "success", surfaced: false };
+  }
+  const base = conclusionForVerdict(verdict);
+  const conclusion = policy === "warn" && base === "failure" ? "neutral" : base;
+  return { policy, conclusion, surfaced: true };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,13 +17,14 @@ import {
 import { formatCost, queryPreview } from "./reporters/github/github.ts";
 import { fetchPrChangedFiles } from "./gate/changed-files.ts";
 import { evaluateTestPresence } from "./gate/test-presence.ts";
+import { resolveVerdict } from "./gate/policy.ts";
 import { DEFAULT_CONFIG } from "./config.ts";
 import { ApiClient } from "./remote/api-client.ts";
 import { Remote } from "./remote/remote.ts";
 import { ConnectionManager } from "./sync/connection-manager.ts";
 import { PgbadgerSource } from "./sql/pgbadger.ts";
 import type { RecentQuerySource } from "./sql/recent-query.ts";
-import type { FullSchema } from "@query-doctor/core";
+import type { FullSchema, RepoPolicyConfig } from "@query-doctor/core";
 
 async function runInCI(
   targetPostgresUrl: Connectable,
@@ -232,21 +233,46 @@ async function runInCI(
       }
     }
 
+    // Resolve the gate verdict's CI conclusion via the shared taxonomy (#3498)
+    // and policy engine (#3500) instead of a local severity. By default an
+    // unverified data-access change concludes `failure`, so it blocks the check —
+    // a "Warning" beside a green check is invisible to downstream reviewers
+    // (Site#3541). A repo can soften it to a non-blocking neutral (`warn`) or
+    // suppress it (`off`). Resolved before the report so `off` also drops the
+    // comment block, and so the comment can render the right framing.
+    if (reportContext.testPresenceVerdict) {
+      const policyConfig: RepoPolicyConfig =
+        ("conditionPolicies" in config ? config.conditionPolicies : undefined) ??
+        {};
+      const resolved = resolveVerdict(
+        reportContext.testPresenceVerdict,
+        policyConfig,
+      );
+      if (resolved.surfaced) {
+        reportContext.testPresenceConclusion = resolved.conclusion;
+      } else {
+        reportContext.testPresenceVerdict = undefined;
+      }
+    }
+
     console.log("Creating report...")
     // Generate PR comment with comparison data
     await runner.report(reportContext);
 
-    // The test-presence gate surfaces as a non-blocking warning, not a red X:
-    // it is a crude diff heuristic, so it warns loudly while the capture-based
-    // rungs (#3502/#3503) are built. Flipping it to a hard failure is opt-in via
-    // the per-repo policy (#3500). Framed as "unverified", never "your query is bad".
+    // Carry the verdict into the check itself: a blocking conclusion fails the
+    // run (red X), a softened one surfaces as a non-blocking annotation. Framed
+    // as "could not verify", never "your query is broken".
     if (reportContext.testPresenceVerdict) {
       const verdict = reportContext.testPresenceVerdict;
       const files = verdict.dataAccessFiles.map((f) => `  - ${f}`).join("\n");
-      core.warning(
+      const message =
         `${verdict.reason}\n\nNext step: ${verdict.nextStep}\n\n` +
-          `Changed data-access files with no related data-layer test:\n${files}`,
-      );
+        `Changed data-access files with no related data-layer test:\n${files}`;
+      if (reportContext.testPresenceConclusion === "failure") {
+        core.setFailed(message);
+      } else {
+        core.warning(message);
+      }
     }
 
     // Block PR if regressions exceed thresholds, or if a brand-new query ships

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -848,11 +848,17 @@ describe("test-presence verdict rendering", () => {
     dataAccessFiles: ["apps/api/src/users/user.repository.ts"],
   };
 
-  test("renders the unverified banner, reason, next step, and flagged file", () => {
-    const output = renderTemplate(makeContext({ testPresenceVerdict: verdict }));
-    expect(output).toContain("[!WARNING]");
+  test("renders a blocking caution block, reason, next step, and flagged file — never a Warning heading", () => {
+    const output = renderTemplate(
+      makeContext({
+        testPresenceVerdict: verdict,
+        testPresenceConclusion: "failure",
+      }),
+    );
+    expect(output).toContain("[!CAUTION]");
+    expect(output).not.toContain("[!WARNING]");
     expect(output).toContain(
-      "Unverified — this PR changes queries with no related data-layer test.",
+      "Could not verify — this PR changes queries with no related data-layer test.",
     );
     expect(output).toContain(verdict.reason);
     expect(output).toContain(verdict.nextStep);
@@ -860,8 +866,23 @@ describe("test-presence verdict rendering", () => {
     expect(output).toContain(verdict.triageHint);
   });
 
-  test("omits the banner entirely when there is no verdict", () => {
+  test("renders a non-blocking note block when the policy softened the verdict to neutral", () => {
+    const output = renderTemplate(
+      makeContext({
+        testPresenceVerdict: verdict,
+        testPresenceConclusion: "neutral",
+      }),
+    );
+    expect(output).toContain("[!NOTE]");
+    expect(output).not.toContain("[!CAUTION]");
+    expect(output).not.toContain("[!WARNING]");
+    expect(output).toContain(verdict.reason);
+  });
+
+  test("omits the block entirely when there is no verdict", () => {
     const output = renderTemplate(makeContext());
-    expect(output).not.toContain("Unverified — this PR changes queries");
+    expect(output).not.toContain(
+      "Could not verify — this PR changes queries",
+    );
   });
 });

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -23,8 +23,8 @@
 
 {% endif %}
 {% if testPresenceVerdict %}
-> [!WARNING]
-> **Unverified — this PR changes queries with no related data-layer test.**
+> [!{{ "CAUTION" if testPresenceConclusion == "failure" else "NOTE" }}]
+> **Could not verify — this PR changes queries with no related data-layer test.**
 > {{ testPresenceVerdict.reason }}
 >
 > **Next step:** {{ testPresenceVerdict.nextStep }}

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -1,4 +1,4 @@
-import type { ComputedStats, IndexIdentifier, StatisticsMode } from "@query-doctor/core";
+import type { CiConclusion, ComputedStats, IndexIdentifier, StatisticsMode } from "@query-doctor/core";
 import type {
   CiRunMetadata,
   IngestFailureKind,
@@ -113,10 +113,16 @@ export interface ReportContext {
   /**
    * The crude test-presence gate (#3496) flagged this PR: data-access code
    * changed with no data-layer test alongside it. Rendered as a conservative
-   * "could not verify" banner in the comment; also fails the check in `main`.
+   * "could not verify" block in the comment; also gates the check in `main`.
    * A pure diff heuristic — independent of the baseline comparison.
    */
   testPresenceVerdict?: TestPresenceVerdict;
+  /**
+   * The gate verdict's resolved CI conclusion (taxonomy #3498 + policy #3500):
+   * `failure` renders the blocking framing, `neutral` the softened `warn` one.
+   * Absent when there is no surfaced verdict.
+   */
+  testPresenceConclusion?: CiConclusion;
 }
 
 export interface IndexStatistic {


### PR DESCRIPTION
## Goal

The CI⇄MCP verdict loop (Query-Doctor/Site epic #3493) wants each condition's pass/fail to come from the shared taxonomy and policy, not each surface's own severity. This PR makes the analyzer's test-presence gate stop deciding its own severity and adopt `@query-doctor/core`'s taxonomy + policy engine. Closes Query-Doctor/Site#3541.

## What

Before: a PR that changed data-access code with no related real-DB test got a **"Warning" callout and a green check**. A warning beside a passing check is invisible to downstream reviewers — human or agent — who key on the check status, so the finding was silently dropped (documented on a live PR in the issue thread).

After: the same PR gets a **failing check** by default. The comment block loses its "Warning" heading — it renders `[!CAUTION]` when blocking, framed as "could not verify", never "your query is broken". A repo can soften the gate to non-blocking (`warn` → `[!NOTE]`, neutral) or suppress it (`off`); those are config, not the default. Adding a real-DB test or triaging the flagged queries and re-running still goes green, unchanged.

## How

Read in this order:

- `src/gate/policy.ts` (new) — `resolveVerdict` maps a gate verdict to its CI conclusion via core's `conclusionForVerdict` (taxonomy #3498) + `policyFor` (policy #3500). `uncertain-conservative-flag` concludes `failure`; `warn` caps that at a surfaced-but-non-blocking `neutral`; `off` reports the condition as unsurfaced.
- `src/main.ts` — resolves the verdict before posting the report (so `off` also drops the comment block and the comment can render the right framing), then carries the conclusion into the check: `core.setFailed` on `failure`, `core.warning` on `neutral`. Replaces the old always-`core.warning` path.
- `src/reporters/github/success.md.j2` — drops `[!WARNING]`; an inline conditional picks `[!CAUTION]` (blocking) or `[!NOTE]` (softened) from the resolved conclusion, kept on one line so the GitHub callout stays contiguous.
- `src/config.ts` / `src/reporters/reporter.ts` — `AnalyzerConfig.conditionPolicies` (optional) carries per-repo overrides; `ReportContext.testPresenceConclusion` drives the comment framing.

Note: `conditionPolicies` is read from the repo config (`"conditionPolicies" in config`) and is empty until Site adds it to `RepoConfig`/`getRepoConfig` — an additive, non-breaking follow-up. Until then every repo gets the safe default (`fail`); the gate honours an override the moment it arrives.

Scope note: this keeps the analyzer's inline `TestPresenceVerdict` (a precursor to the full `CiVerdict` contract #3497) rather than migrating to it, so the change stays surgical. It uses the two functions the issue names directly rather than `evaluateRun`, which would require the full contract.

## Tests

- `src/gate/policy.test.ts` (new) — `resolveVerdict`: blocks by default (`fail`→`failure`), softens under `warn` (→`neutral`, surfaced), suppresses under `off` (unsurfaced), and keeps a `pass` verdict green even under `fail` (proving the taxonomy, not a blanket fail, drives it).
- `src/reporters/github/github.test.ts` — the block renders `[!CAUTION]` for a blocking verdict and `[!NOTE]` for a softened one, and never `[!WARNING]`.
- Full suite green: 311 passed (30 files). Typecheck clean, build succeeds.