### PR TITLE
feat: cost schema the production snapshot doesn't cover via the synthesizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.15.0",
+        "@query-doctor/core": "^0.16.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-V9nzzB9ZkaDleINlBX8yUcv6jVZ1nGZF5TXCTdpkeBEuFBWTTWOsXT8N8k+x5S6CWpNPIjhjXCubiodSL7oqyA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-7J/W5tz76g3U70kSaBU3cTTCqFQ1Bmu+PqUSJBf9mlvL9WAbwWxJoa+eL90dNmLuyAyjEG6Gzf8QDFc0Qd8hwA==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.15.0",
+    "@query-doctor/core": "^0.16.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/remote/query-optimizer-synthesis.test.ts
+++ b/src/remote/query-optimizer-synthesis.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "vitest";
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { dumpSchema, PostgresVersion, Statistics } from "@query-doctor/core";
+import { ConnectionManager } from "../sync/connection-manager.ts";
+import { Connectable } from "../sync/connectable.ts";
+import { QueryOptimizer } from "./query-optimizer.ts";
+
+// When the exported snapshot doesn't cover a table in the current schema — added
+// on this branch since the snapshot was captured — setStatistics must pass the
+// schema through to core's Statistics so the synthesizer sizes that table,
+// instead of it falling to the flat default. This is the analyzer-side wiring;
+// the synthesis logic itself is covered in @query-doctor/core.
+//
+// Requires @query-doctor/core >= 0.13.0 (the currentSchema parameter and the
+// syntheticTables getter).
+test(
+  "setStatistics sizes a table missing from the exported snapshot",
+  async () => {
+    const pg = await new PostgreSqlContainer("postgres:17")
+      .withCopyContentToContainer([
+        {
+          content: `
+            create table orders (id serial primary key);
+            create table refunds (id serial primary key, order_id int references orders(id));
+            insert into orders default values;
+            insert into refunds (order_id) values (1);
+          `,
+          target: "/docker-entrypoint-initdb.d/init.sql",
+        },
+      ])
+      .start();
+
+    try {
+      const manager = ConnectionManager.forLocalDatabase();
+      const conn = Connectable.fromString(pg.getConnectionUri());
+      const optimizer = new QueryOptimizer(manager, conn);
+
+      const version = PostgresVersion.parse("17");
+      const connection = manager.getOrCreateConnection(conn);
+      const ownStats = await Statistics.dumpStats(connection, version);
+
+      // refunds is omitted from the snapshot (uncovered); orders is given a
+      // production-sized count so synthesis yields a large number rather than
+      // the single branch row.
+      const snapshot = ownStats
+        .filter((t) => t.tableName !== "refunds")
+        .map((t) => ({
+          ...t,
+          reltuples: t.tableName === "orders" ? 1_000_000 : t.reltuples,
+        }));
+      const schema = await dumpSchema(connection);
+
+      await optimizer.setStatistics(
+        Statistics.statsModeFromExport(snapshot),
+        schema,
+      );
+
+      // refunds is reported as modeled/unverified and sized from the 1M-row
+      // snapshot (via its foreign key to orders), not its own one row.
+      expect(
+        optimizer.syntheticTables.some((t) => t.endsWith(".refunds")),
+      ).toBe(true);
+      const refunds = optimizer.computedStats?.reltuples.find(
+        (r) => r.relname === "refunds",
+      );
+      expect(refunds?.reltuples).toBeGreaterThan(100_000);
+    } finally {
+      await pg.stop();
+    }
+  },
+  120_000,
+);

--- a/src/remote/query-optimizer.ts
+++ b/src/remote/query-optimizer.ts
@@ -113,6 +113,15 @@ export class QueryOptimizer extends EventEmitter<EventMap> {
     return this.target?.statistics.ownMetadata;
   }
 
+  /**
+   * Tables ("schema.table") sized by the synthesizer because the exported
+   * snapshot didn't cover them — their costs are modeled, not verified. Empty
+   * unless a schema was supplied in fromStatisticsExport mode.
+   */
+  get syntheticTables(): string[] {
+    return this.target?.statistics.syntheticTables ?? [];
+  }
+
   getExistingIndexes(): FullSchemaIndex[] {
     return this.existingIndexes;
   }
@@ -146,7 +155,11 @@ export class QueryOptimizer extends EventEmitter<EventMap> {
     const version = PostgresVersion.parse("17");
     const pg = this.manager.getOrCreateConnection(this.connectable);
     const ownStats = await Statistics.dumpStats(pg, version);
-    const statistics = new Statistics(pg, version, ownStats, statsMode);
+    // Pass the current schema so tables the exported snapshot doesn't cover
+    // (added on this branch / since the snapshot was captured) are sized by the
+    // synthesizer instead of the flat default. No-op when statsMode isn't
+    // fromStatisticsExport.
+    const statistics = new Statistics(pg, version, ownStats, statsMode, schema);
     this.existingIndexes = schema?.indexes ?? [];
     const filteredIndexes = this.filterDisabledIndexes(this.existingIndexes);
     const optimizer = new IndexOptimizer(pg, statistics, filteredIndexes, {

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -130,6 +130,13 @@ export interface ReportContext {
    * Absent when there is no surfaced verdict.
    */
   testPresenceConclusion?: CiConclusion;
+  /**
+   * Tables ("schema.table") in the analyzed schema the production snapshot
+   * doesn't cover, so their costs were modeled by the synthesizer rather than
+   * verified against real data. Empty when the snapshot covers the whole schema.
+   * Not yet rendered in the comment — plumbed for the surfacing that follows.
+   */
+  modeledTables?: string[];
 }
 
 export interface IndexStatistic {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -202,6 +202,7 @@ export class Runner {
     const reportContext: ReportContext = {
       statisticsMode: this.remote.optimizer.statisticsMode,
       computedStats: this.remote.optimizer.computedStats,
+      modeledTables: this.remote.optimizer.syntheticTables,
       recommendations: filteredRecommendations,
       belowThresholdRecommendations,
       queriesPastThreshold: filteredThresholdWarnings,


### PR DESCRIPTION
### Goal

The analyzer side of Production Statistics ([Site#3587](https://github.com/Query-Doctor/Site/pull/3587), ADR 0007). Makes the core synthesizer actually run on the connected and CI costing paths, so a table the production snapshot has never seen is costed with an extrapolated row count instead of the flat 10M default.

> **Blocked on `@query-doctor/core@0.16.0`.** It publishes when Site#3587 merges to staging. Until then `npm install` can't resolve the range and CI is red — expected, and the only thing left blocking this branch.

### What

Before, `QueryOptimizer.setStatistics` built `Statistics` without the current schema, so a table outside the snapshot's coverage fell to the default and an unindexed scan over it looked free. After, the schema is passed in, so those tables are sized by the synthesizer — foreign-key graph, then shape class, then database median — with column stats inferred from type and constraints.

Both the connected and CI paths already thread the schema through `onSuccessfulSync → optimizer.start`, so one wiring change covers both.

### How

- `query-optimizer.ts` — pass `schema` as the fifth `Statistics` argument (the only `new Statistics` in this repo), and add a `syntheticTables` getter mirroring `computedStats` / `ownMetadata`.
- `reporter.ts` / `runner.ts` — plumb the synthesized-table set onto `ReportContext.modeledTables`.
- `package.json` — `@query-doctor/core` to `^0.16.0`, the minor that adds the `currentSchema` constructor argument and the `syntheticTables` getter.

The push path is unaffected: it sends `ownMetadata` (`remote.ts:392`), and synthesized numbers live only in `computedStats`. A modeled row count can't reach the stored snapshot.

### Deferred to a follow-up

Rendering the **"modeled, not verified" banner** in the PR comment — template, `buildViewModel`, snapshot regen. Left until core publishes so the template and snapshot tests are validated rather than written blind. That banner is the half of [Site#3420](https://github.com/Query-Doctor/Site/issues/3420) a developer actually sees, so this branch does not close it on its own.

### Sequencing

1. Site#3587 → staging → core publishes `0.16.0`.
2. Here: `npm install` to sync the lockfile (it still carries `^0.15.0` from main), CI goes green.
3. Then the comment-render follow-up.

### Tests

`query-optimizer-synthesis.test.ts` covers the wiring: that `setStatistics` forwards the schema, and that `syntheticTables` reports tables the snapshot doesn't cover. It runs against a testcontainer and goes green once core publishes.
