### PR TITLE
fix: exclude test-origin queries from the gate (bump core to 0.13.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.12.0",
+        "@query-doctor/core": "^0.13.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1100,6 +1100,12 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@pgsql/quotes": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@pgsql/quotes/-/quotes-17.1.0.tgz",
+      "integrity": "sha512-J/H+LcrENBpYgL45WW6aTjb5Yk4tX4+AmB2/k8KZa+Zh3wiCtqmNIag+HZz5HmWaF6EZK9ZGC95NBD1fs+rUvg==",
+      "license": "MIT"
+    },
     "node_modules/@pgsql/types": {
       "version": "17.6.2",
       "resolved": "https://registry.npmjs.org/@pgsql/types/-/types-17.6.2.tgz",
@@ -1187,17 +1193,27 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-z2uCIHuHKjcqYTDWW5s13K0iUfBIN5mYZsTNHYzO7FwYuglshWEpsq2bLLLiegL1eqzYK+Et6QF7qy/Vs0TUBw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-xhSgpFLAIVNAIu4V9u9POkdRSvLIH3J/ekz5OXrnN45ObEg8vdSMyqOuwt5ADT8G+PhTbiElFhfPJwHQ2xfDFA==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
-        "capnweb": "^0.7.0",
+        "capnweb": "^0.10.0",
         "colorette": "^2.0.20",
         "dedent": "^1.7.2",
-        "pgsql-deparser": "^17.17.2",
+        "pgsql-deparser": "^17.18.4",
         "zod": "^4.3.6"
       }
+    },
+    "node_modules/@query-doctor/core/node_modules/capnweb": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.10.0.tgz",
+      "integrity": "sha512-lQ2nlzaifkqBeNfs8RLErn7NZ8FNf3vn1W7J3nSH73edWG+0B5nHZGR51S2S9HMZEuZcEypOO469dZRY/BluFA==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ]
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -4366,11 +4382,12 @@
       }
     },
     "node_modules/pgsql-deparser": {
-      "version": "17.17.2",
-      "resolved": "https://registry.npmjs.org/pgsql-deparser/-/pgsql-deparser-17.17.2.tgz",
-      "integrity": "sha512-FCjqKY3Sdmce3VUd3CxCXF0kqaZ0s4a6yIMT5UJ9vETh0cF54A8Tpqjn0qBKaPUD8xqTKeLdS+SfiwjAC64wrA==",
+      "version": "17.18.5",
+      "resolved": "https://registry.npmjs.org/pgsql-deparser/-/pgsql-deparser-17.18.5.tgz",
+      "integrity": "sha512-C23etz+aWjp5d09SQwrByisCIV0Zy1dPI0IdBPBaRiMRrDQ2MH8O9txvqpxPyWiXEGRU+MMvZqk48UHxWWbODg==",
       "license": "MIT",
       "dependencies": {
+        "@pgsql/quotes": "17.1.0",
         "@pgsql/types": "^17.6.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.12.0",
+    "@query-doctor/core": "^0.13.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/remote/api-client.ts
+++ b/src/remote/api-client.ts
@@ -1,6 +1,6 @@
 import { newWebSocketRpcSession, RpcTarget } from "capnweb";
 import type { RpcStub } from "capnweb";
-import type { ConnectionMode, UnauthenticatedServerApi, ClientApi, IndexDefinition, ServerApi } from "@query-doctor/core";
+import type { ConnectionMode, UnauthenticatedServerApi, ClientApi, IndexDefinition, LiveQueryOptimization, ServerApi } from "@query-doctor/core";
 import type { ExportedStats } from "@query-doctor/core";
 import { PgIdentifier, Statistics } from "@query-doctor/core";
 import { log } from "../log.ts";
@@ -183,7 +183,10 @@ export class ApiClient extends RpcTarget implements ClientApi {
     );
   }
 
-  async runQuery(_query: string): Promise<void> {
-    log.warn("runQuery is not implemented", ApiClient.name);
+  async runQuery(_query: string): Promise<LiveQueryOptimization> {
+    // Part of the ClientApi RPC surface (core 0.13.0) but never invoked on the
+    // CI client — throw rather than return a fabricated optimization, so a stray
+    // call surfaces loudly instead of silently yielding a bogus result.
+    throw new Error("runQuery is not implemented on the CI ApiClient");
   }
 }

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -245,6 +245,30 @@ describe("compareRuns", () => {
       expect(result.regressed).toHaveLength(1);
       expect(result.testOriginExcluded).toHaveLength(0);
     });
+
+    // Real SQLCommenter `file` tags carry a `:line:col` suffix
+    // (`…repository.spec.ts:509:10`). Before core stripped that suffix, the
+    // `$`-anchored `.spec.ts` pattern never matched, so a test read-back leaked
+    // into newQueries and phantom-blocked unrelated PRs run after run — the
+    // server dropped it as test-origin while the analyzer did not (Site #3606).
+    test("excludes a .spec.ts query whose file tag carries a :line:col suffix", async () => {
+      const withSuffix: CiQueryPayload = {
+        ...makeQuery("hash-new", 200),
+        tags: [
+          {
+            key: "file",
+            value:
+              "/home/runner/work/Site/Site/apps/api/src/projects/project-queries.repository.spec.ts:509:10",
+          },
+        ],
+      };
+      const previousRun = makePreviousRun([]);
+
+      const result = await compareRuns([withSuffix], previousRun, 10);
+
+      expect(result.newQueries).toHaveLength(0);
+      expect(result.testOriginExcluded.map((q) => q.hash)).toEqual(["hash-new"]);
+    });
   });
 
   describe("changed-query detection via shape (#3367)", () => {


### PR DESCRIPTION
## Goal

Stop the new-query gate from phantom-blocking PRs on Query Doctor's own repo — including docs-only ones — with queries that were never added by the PR. Fixes Query-Doctor/Site#3606.

## What

Before: the `analyzer / Analyzer` check failed with "N new queries ship with a high-impact index recommendation", listing Query Doctor's own test read-backs of `project_queries` (`SELECT "normalized_fingerprint" FROM "project_queries" WHERE "hash" = $1` and its full-row sibling, cost 17, 51% cut). These recur on every run against every baseline, so a rebase doesn't clear them.

After: those queries are recognized as test-origin and bucketed out of the gate, matching what the Site API already does. A genuinely new query still gates.

## How

Root cause is a client/server version skew of one shared rule:

- The flagged queries are raw `db.select()` read-backs in `apps/api/src/projects/project-queries.repository.spec.ts` (lines 479 and 506, helper `readFingerprint`). Their SQLCommenter `file` tag is `…project-queries.repository.spec.ts:509:10` — a `:line:col` suffix on the path.
- `isTestOriginQuery` must strip that suffix before the `$`-anchored `.spec.ts` pattern can match. Core **0.12.1** added the strip. The Site API adopted it (it stopped storing these queries around July 15), but the analyzer bundled an older core (installed `0.10.10`), so `compareRuns` never moved them to `testOriginExcluded` — they stayed in `newQueries` and the gate fired. Since the server never stores them, no stored baseline ever contains them, so they read as "new" run after run.

The fix is the dependency bump; there is no gate-logic change. Read `package.json` first, then `src/remote/api-client.ts`, then the test.

- `@query-doctor/core` `^0.12.0` → `^0.13.0` so the analyzer applies the same test-origin rule as the server.
- 0.13.0 adds `runQuery` to the `ClientApi` RPC surface. The CI `ApiClient` doesn't implement it (nothing calls it there), so its stub now throws to satisfy the new return type rather than silently returning `undefined`.

Verified against the prod Site DB: the two runs behind #3606 store an identical 91-hash set as their baselines (server rollup `new: 0`), and the catalog shows these two hashes with `last_seen_source = ci` frozen at `2026-07-15 01:00` — the point the server started dropping them.

## Tests

- New `compareRuns` case: a `.spec.ts` query whose `file` tag carries a `:line:col` suffix is excluded (`testOriginExcluded`, not `newQueries`). Fails on pre-0.12.1 core, passes now.
- Full suite green (29 files, 307 tests), typecheck clean.

Follow-up (deploy, not in this PR): cut a new analyzer action release so CI runs pick up the bumped core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)