### PR TITLE
fix(gate): require whitespace after `select` in the raw-query shape

### DIFF
--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -201,6 +201,33 @@ describe("classifyChangedFiles", () => {
     ]);
     expect(surface.dataAccessChanged).toEqual(["apps/api/src/schema.ts"]);
   });
+
+  test("does not read a `select-plan` route path as a SELECT ... FROM query", () => {
+    // Site#3615 root cause: `\bselect\b` matched the hyphenated route segment,
+    // and an import `from` on the next line completed the `SELECT ... FROM`
+    // shape. Requiring whitespace after `select`, as real SQL has, fixes it.
+    const surface = classifyChangedFiles([
+      {
+        path: "apps/app/src/routeTree.gen.ts",
+        status: "modified",
+        patch:
+          "@@ -18,2 +18,2 @@\n" +
+          "+} from './routes/membership/select-plan'\n" +
+          "+import { Route as MembershipRegisterRouteImport } from './routes/membership/register'",
+      },
+    ]);
+    expect(surface.dataAccessChanged).toEqual([]);
+  });
+
+  test("still flags a raw SELECT ... FROM query in application code", () => {
+    // The tightened `select`-shape must keep its recall: real SQL has whitespace
+    // after the keyword. This trips only the raw select shape (no `db.`, no
+    // `.query(`), so it locks that pattern in.
+    const surface = classifyChangedFiles([
+      changed("apps/api/src/reports.ts", "const sql = `SELECT id, name FROM users`;"),
+    ]);
+    expect(surface.dataAccessChanged).toEqual(["apps/api/src/reports.ts"]);
+  });
 });
 
 describe("evaluateTestPresence", () => {
@@ -252,6 +279,23 @@ describe("evaluateTestPresence", () => {
         "tests/pg/postgres.test.ts",
         "expect(await db.select().from(projects)).toEqual([p]);",
       ),
+    ]);
+    expect(verdict).toBeNull();
+  });
+
+  test("does not fire on the route-tree regeneration from Site#3614", () => {
+    // The reported false positive: a routeTree.gen.ts regeneration (import
+    // re-ordering) whose `select-plan` route path read as `SELECT ... FROM`.
+    // No data access, nothing to flag.
+    const verdict = evaluateTestPresence([
+      {
+        path: "apps/app/src/routeTree.gen.ts",
+        status: "modified",
+        patch:
+          "@@ -18,2 +18,2 @@\n" +
+          "+} from './routes/membership/select-plan'\n" +
+          "+import { Route as MembershipRegisterRouteImport } from './routes/membership/register'",
+      },
     ]);
     expect(verdict).toBeNull();
   });

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -76,7 +76,11 @@ export const DEFAULT_TEST_PRESENCE_CONFIG: TestPresenceConfig = {
     /\binsert\s+into\b/i,
     /\bdelete\s+from\b/i,
     /\bupdate\b[^\n]{0,80}\bset\b/i,
-    /\bselect\b[\s\S]{0,300}?\bfrom\b/i,
+    // `select` must be followed by whitespace, as real `SELECT … FROM` is — so a
+    // hyphenated route segment like `select-plan` (whose `\bselect\b` boundary is
+    // the hyphen) doesn't read as a query when an import `from` follows it
+    // (Site#3615).
+    /\bselect\s[\s\S]{0,300}?\bfrom\b/i,
     // DDL is matched by statement shape (ON clause, column list, target
     // identifier), not bare keyword adjacency: prose in a string literal —
     // "its suggested CREATE INDEX fix" in an MCP tool description (Site#3539)


### PR DESCRIPTION
### Goal

Stop the `untested-data-access` CI gate from reporting false positives to users. Tracked in Query-Doctor/Site#3615 (dogfooding); the triggering PR was Site#3614, a TanStack Router route-tree regeneration.

### What

Before: a PR that regenerated `apps/app/src/routeTree.gen.ts` was flagged as changing an untested query, listing that file under "changed data-access files with no related data-layer test". The file has no data access — it is route wiring.

After: the regeneration is not flagged. A route path no longer reads as a SQL query.

### How

The gate's raw-query heuristic included `/\bselect\b[\s\S]{0,300}?\bfrom\b/i`. `\bselect\b` matched the `/membership/select-plan` route path because the hyphen is a word boundary, and an import `from` two lines down completed the shape — so a route path parsed as `SELECT … FROM`.

The one-line fix requires whitespace after `select`, as real `SELECT … FROM` has:

```
- /\bselect\b[\s\S]{0,300}?\bfrom\b/i
+ /\bselect\s[\s\S]{0,300}?\bfrom\b/i
```

`select-plan` (hyphen), `select.foo` (dot), `select/x` (slash) no longer match. Camel/underscore identifiers (`selectPlan`, `select_plan`) never matched `\bselect\b`, so they are unaffected. Read `src/gate/test-presence.ts` first (the pattern), then the tests.

### Tests

`src/gate/test-presence.test.ts`:
- the `select-plan` route path is not classified as data-access (the reported case);
- a raw `SELECT id, name FROM users` still is — recall guard, so the tightening doesn't blind the raw-SQL shape;
- the end-to-end Site#3614 regeneration produces no verdict.

Full suite green (310 tests), typecheck clean.

Refs Query-Doctor/Site#3615