### PR TITLE
chore(deps): adopt @query-doctor/core ^0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.13.0",
+        "@query-doctor/core": "^0.14.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,15 +1193,15 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-xhSgpFLAIVNAIu4V9u9POkdRSvLIH3J/ekz5OXrnN45ObEg8vdSMyqOuwt5ADT8G+PhTbiElFhfPJwHQ2xfDFA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-1F1bCELQixBliEHbrfm25z4hl2dhBzBE1Ckwj/d33aQrQcE6a6+aw+ExM9vX0rzkOENBfZNAjN8uLIuPS1MAaQ==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",
         "colorette": "^2.0.20",
         "dedent": "^1.7.2",
-        "pgsql-deparser": "^17.18.4",
+        "pgsql-deparser": "^17.18.5",
         "zod": "^4.3.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.13.0",
+    "@query-doctor/core": "^0.14.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
### What

Bumps the `@query-doctor/core` range to `^0.14.0`. Core 0.14.0 classifies `MERGE` (PG 15+ DML) as `statementType: "merge"` instead of `"other"`, so the non-DML push filter from #179 (`!== "other"`) stops silently dropping MERGE statements from the query catalog. No analyzer code change needed.

### Status

**Draft — blocked on core publish.** Core 0.14.0 ships when Query-Doctor/Site PR #3583 merges to staging. Until then the lockfile can't resolve `^0.14.0`. Once it's on npm: `npm install`, push, mark ready.