### PR TITLE
feat(gate): route cost-regression blocking through the policy engine

### DIFF
--- a/src/gate/regression.test.ts
+++ b/src/gate/regression.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { gateRegression } from "./regression.ts";
+
+describe("gateRegression", () => {
+  it("blocks untriaged regressions by default", () => {
+    expect(gateRegression(2)).toEqual({ conclusion: "failure" });
+  });
+
+  it("softens to a non-blocking warning under a warn policy", () => {
+    expect(
+      gateRegression(2, { "regression-beyond-threshold": "warn" })?.conclusion,
+    ).toBe("neutral");
+  });
+
+  it("drops the gate under an off policy", () => {
+    expect(
+      gateRegression(2, { "regression-beyond-threshold": "off" }),
+    ).toBeNull();
+  });
+
+  it("passes when there are no regressions", () => {
+    expect(gateRegression(0)).toBeNull();
+  });
+});

--- a/src/gate/regression.ts
+++ b/src/gate/regression.ts
@@ -1,0 +1,39 @@
+// The cost-regression gate. `compareRuns` already produces the untriaged,
+// beyond-threshold regression set (`comparison.regressed`, filtered by
+// `acknowledgedQueryHashes` and `regressionThreshold`); this gate only decides
+// the check outcome from its size and the repo policy. It blocks by default —
+// unchanged from the old inline path — but now routes through the shared policy
+// engine (#3500), so a repo can soften it to `warn` or `off` the way it can for
+// untested-data-access and schema-drift. Detection is not this gate's job.
+
+import type { RepoPolicyConfig } from "@query-doctor/core";
+import { resolveVerdict } from "./policy.ts";
+
+export interface RegressionGateResult {
+  /** `failure` blocks the check; `neutral` is a surfaced, non-blocking warning. */
+  conclusion: "failure" | "neutral";
+}
+
+/**
+ * Decide the regression gate from the untriaged regression count and the repo
+ * policy. Returns the check outcome when there are regressions and the policy
+ * surfaces them, or `null` when there are none or the policy is `off`.
+ *
+ * `regression-beyond-threshold` is a `finding` in the shared taxonomy (concludes
+ * `failure`) and defaults to `fail`, so a repo that sets nothing blocks exactly
+ * as before. This is a second, repo-wide override layer on top of per-query
+ * triage: `off` suppresses the condition regardless of triage, `warn` surfaces
+ * every untriaged regression without blocking, `fail` blocks them as today.
+ */
+export function gateRegression(
+  regressedCount: number,
+  config: RepoPolicyConfig = {},
+): RegressionGateResult | null {
+  if (regressedCount <= 0) return null;
+  const { conclusion, surfaced } = resolveVerdict(
+    { condition: "regression-beyond-threshold", verdictClass: "finding" },
+    config,
+  );
+  if (!surfaced || conclusion === "success") return null;
+  return { conclusion };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
 import { formatCost, queryPreview } from "./reporters/github/github.ts";
 import { fetchPrChangedFiles } from "./gate/changed-files.ts";
 import { evaluateTestPresence } from "./gate/test-presence.ts";
+import { gateRegression } from "./gate/regression.ts";
 import { resolveVerdict } from "./gate/policy.ts";
 import { DEFAULT_CONFIG } from "./config.ts";
 import { ApiClient } from "./remote/api-client.ts";
@@ -288,20 +289,33 @@ async function runInCI(
         return queryLink ? `\n    ${queryLink}` : "";
       };
 
-      const blockingMessages: string[] = [];
+      const policyConfig: RepoPolicyConfig =
+        ("conditionPolicies" in config ? config.conditionPolicies : undefined) ??
+        {};
 
       const { regressed, newQueries } = reportContext.comparison;
-      if (regressed.length > 0) {
+
+      // Regression arm routed through the shared policy engine (#3500), so a repo
+      // can soften it to warn/off like untested-data-access and schema-drift.
+      // `regressed` is already the untriaged, beyond-threshold set; the policy is
+      // a second, repo-wide layer on top of per-query triage. Default `fail`, so
+      // a repo that sets nothing blocks exactly as the old inline path did.
+      const regressionGate = gateRegression(regressed.length, policyConfig);
+      if (regressionGate) {
         const messages = regressed.map((q) => {
           const preview = queryPreview(q.formattedQuery);
           const cost = `cost ${formatCost(q.previousCost)} → ${formatCost(q.currentCost)} (+${q.regressionPercentage.toFixed(1)}%)`;
           return `  - ${preview}: ${cost}${linkFor(q.hash)}`;
         });
-        blockingMessages.push(
-          `${regressed.length} untriaged regression(s) beyond threshold:\n${messages.join("\n")}`,
-        );
+        const message = `${regressed.length} untriaged regression(s) beyond threshold:\n${messages.join("\n")}`;
+        if (regressionGate.conclusion === "failure") core.setFailed(message);
+        else core.warning(message);
       }
 
+      // New-query arm stays on its inline setFailed. Its default policy is
+      // `warn`, so routing it through resolveVerdict would silently stop it
+      // blocking — a behavior change that needs a human sign-off, tracked
+      // separately from this regression-only task.
       const gateNewQueries = gateEligibleNewQueries(
         newQueries,
         config.regressionThreshold,
@@ -318,13 +332,9 @@ async function runInCI(
           const detail = `cost ${formatCost(opt.cost)}, index recommendation cuts it ${opt.costReductionPercentage.toFixed(1)}%`;
           return `  - ${preview}: ${detail}${linkFor(q.hash)}`;
         });
-        blockingMessages.push(
+        core.setFailed(
           `${gateNewQueries.length} new quer${gateNewQueries.length === 1 ? "y" : "ies"} ship${gateNewQueries.length === 1 ? "s" : ""} with a high-impact index recommendation (acknowledge on the dashboard to allow):\n${messages.join("\n")}`,
         );
-      }
-
-      if (blockingMessages.length > 0) {
-        core.setFailed(blockingMessages.join("\n\n"));
       }
     }
   } finally {


### PR DESCRIPTION
### Goal

Cost-regression already blocks a PR, but through the analyzer's old inline path. A repo can set `untested-data-access` (#183) and `schema-drift` (#188) to `warn`/`off` per-repo; it couldn't do the same for regression. This routes the regression gate through the shared policy engine so it's overridable the same way.

Regression already fails today, so this adds no new blocking — only per-repo overridability.

### What

Before: a beyond-threshold, untriaged cost regression always fails the check, with no way to soften it. After: the same regression still fails by default, but a repo can set the `regression-beyond-threshold` policy to `warn` (surfaced, non-blocking) or `off` (suppressed) in CI settings, exactly as it already can for the other two conditions.

`regression-beyond-threshold` is a `finding` in the shared taxonomy (concludes `failure`) and defaults to `fail` in `DEFAULT_CONDITION_POLICIES`, so a repo that configures nothing is unaffected.

### How

- **`src/gate/regression.ts`** (new) — a pure helper `gateRegression(regressedCount, policyConfig)` that builds the `{ condition: "regression-beyond-threshold", verdictClass: "finding" }` verdict, runs it through `resolveVerdict`, and returns `{ conclusion } | null`. Mirrors `gateSchemaChange` from #188. Detection is not its job; it only decides the check outcome from a count already computed upstream.
- **`src/main.ts`** — the regression arm inside `if (reportContext.comparison)` now calls `gateRegression` and emits `core.setFailed` on `failure`, `core.warning` on `neutral`. The per-query message text (previews, cost delta, dashboard links) is unchanged. Regression and new-query now emit their own annotations instead of one joined `setFailed`, consistent with how the test-presence gate already calls `setFailed` independently just above.

`regressed` is already the untriaged, beyond-threshold set (`compareRuns` filters by `acknowledgedQueryHashes` and `regressionThreshold`), so the gate does not re-filter.

**New-query gate left untouched, on purpose.** `gateEligibleNewQueries` (a new query shipping a high-impact index) currently blocks via inline `setFailed`. But `new-query` defaults to `warn` in `DEFAULT_CONDITION_POLICIES`, so routing it through `resolveVerdict` would silently stop it blocking. That may be desirable, but it's a behavior change to sign off on separately. This PR is regression only.

### Triage vs. policy — two override layers

`regressed` is *untriaged* already, so there are now two independent override layers:

- **Per-query triage** (acknowledge/resolve/ignore) removes an individual regression from the set.
- **Per-repo `regression-beyond-threshold` policy** applies to whatever survives triage: `off` suppresses the whole condition regardless of triage; `warn` surfaces all untriaged regressions without blocking; `fail` (default) blocks them as today.

### Tests

- `src/gate/regression.test.ts` — the pure helper: blocks by default, `warn` → `neutral`, `off` → `null`, zero regressions → `null`.
- Full suite green: `npm test -- run` → 321 passing (32 files). Typecheck clean; build succeeds. (The pre-existing `site-api.test.ts` red and the `api-client.ts` type errors noted in the hand-off were already resolved on `main` by the `@query-doctor/core ^0.14.0` adoption.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)