### PR TITLE
feat(gate): route new-query blocking through the policy engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.14.0",
+        "@query-doctor/core": "^0.15.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,16 +1193,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-1F1bCELQixBliEHbrfm25z4hl2dhBzBE1Ckwj/d33aQrQcE6a6+aw+ExM9vX0rzkOENBfZNAjN8uLIuPS1MAaQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-V9nzzB9ZkaDleINlBX8yUcv6jVZ1nGZF5TXCTdpkeBEuFBWTTWOsXT8N8k+x5S6CWpNPIjhjXCubiodSL7oqyA==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",
         "colorette": "^2.0.20",
         "dedent": "^1.7.2",
         "pgsql-deparser": "^17.18.5",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@query-doctor/core/node_modules/capnweb": {
@@ -5961,9 +5961,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.14.0",
+    "@query-doctor/core": "^0.15.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/gate/new-query.test.ts
+++ b/src/gate/new-query.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { gateNewQuery } from "./new-query.ts";
+
+describe("gateNewQuery", () => {
+  it("blocks eligible new queries by default", () => {
+    expect(gateNewQuery(2)).toEqual({ conclusion: "failure" });
+  });
+
+  it("softens to a non-blocking warning under a warn policy", () => {
+    expect(
+      gateNewQuery(2, { "new-query-index": "warn" })?.conclusion,
+    ).toBe("neutral");
+  });
+
+  it("drops the gate under an off policy", () => {
+    expect(gateNewQuery(2, { "new-query-index": "off" })).toBeNull();
+  });
+
+  it("passes when there are no eligible new queries", () => {
+    expect(gateNewQuery(0)).toBeNull();
+  });
+});

--- a/src/gate/new-query.ts
+++ b/src/gate/new-query.ts
@@ -1,0 +1,39 @@
+// The new-query gate. `gateEligibleNewQueries` already produces the actionable
+// set — new, diff-introduced queries that ship with a beyond-threshold index
+// recommendation and aren't acknowledged; this gate only decides the check
+// outcome from its size and the repo policy. It blocks by default — unchanged
+// from the old inline path — but now routes through the shared policy engine
+// (#3500), so a repo can soften it to `warn` or `off` the way it can for
+// regressions and untested-data-access. Detection is not this gate's job.
+
+import type { RepoPolicyConfig } from "@query-doctor/core";
+import { resolveVerdict } from "./policy.ts";
+
+export interface NewQueryGateResult {
+  /** `failure` blocks the check; `neutral` is a surfaced, non-blocking warning. */
+  conclusion: "failure" | "neutral";
+}
+
+/**
+ * Decide the new-query gate from the eligible-new-query count and the repo
+ * policy. Returns the check outcome when there are eligible new queries and the
+ * policy surfaces them, or `null` when there are none or the policy is `off`.
+ *
+ * A plain new query is informational (`new-query` defaults to `warn`), but a new
+ * query carrying a high-impact index recommendation is actionable while it's
+ * still a one-line fix, so it routes under its own `new-query-index` key, a
+ * `finding` in the shared taxonomy that defaults to `fail`. A repo that sets
+ * nothing blocks exactly as the old inline path did.
+ */
+export function gateNewQuery(
+  eligibleCount: number,
+  config: RepoPolicyConfig = {},
+): NewQueryGateResult | null {
+  if (eligibleCount <= 0) return null;
+  const { conclusion, surfaced } = resolveVerdict(
+    { condition: "new-query-index", verdictClass: "finding" },
+    config,
+  );
+  if (!surfaced || conclusion === "success") return null;
+  return { conclusion };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { formatCost, queryPreview } from "./reporters/github/github.ts";
 import { fetchPrChangedFiles } from "./gate/changed-files.ts";
 import { evaluateTestPresence } from "./gate/test-presence.ts";
 import { gateRegression } from "./gate/regression.ts";
+import { gateNewQuery } from "./gate/new-query.ts";
 import { gateSchemaChange } from "./gate/schema-change.ts";
 import { resolveVerdict } from "./gate/policy.ts";
 import { DEFAULT_CONFIG } from "./config.ts";
@@ -329,17 +330,20 @@ async function runInCI(
         else core.warning(message);
       }
 
-      // New-query arm stays on its inline setFailed. Its default policy is
-      // `warn`, so routing it through resolveVerdict would silently stop it
-      // blocking — a behavior change that needs a human sign-off, tracked
-      // separately from this regression-only task.
+      // New-query arm routed through the shared policy engine (#3500). A plain
+      // new query is informational (`new-query` defaults to `warn`), but one that
+      // ships with a beyond-threshold index recommendation is actionable, so
+      // `gateEligibleNewQueries` scopes to that set and the gate routes under the
+      // `new-query-index` key, which defaults `fail` — blocking exactly as the old
+      // inline path did, while letting a repo soften it to warn/off.
       const gateNewQueries = gateEligibleNewQueries(
         newQueries,
         config.regressionThreshold,
         config.acknowledgedQueryHashes,
         config.minimumCost,
       );
-      if (gateNewQueries.length > 0) {
+      const newQueryGate = gateNewQuery(gateNewQueries.length, policyConfig);
+      if (newQueryGate) {
         const messages = gateNewQueries.map((q) => {
           const preview = queryPreview(q.formattedQuery);
           // gateEligibleNewQueries only returns improvements_available entries.
@@ -350,9 +354,9 @@ async function runInCI(
           const detail = `cost ${formatCost(opt.cost)}, index recommendation cuts it ${opt.costReductionPercentage.toFixed(1)}%`;
           return `  - ${preview}: ${detail}${linkFor(q.hash)}`;
         });
-        core.setFailed(
-          `${gateNewQueries.length} new quer${gateNewQueries.length === 1 ? "y" : "ies"} ship${gateNewQueries.length === 1 ? "s" : ""} with a high-impact index recommendation (acknowledge on the dashboard to allow):\n${messages.join("\n")}`,
-        );
+        const message = `${gateNewQueries.length} new quer${gateNewQueries.length === 1 ? "y" : "ies"} ship${gateNewQueries.length === 1 ? "s" : ""} with a high-impact index recommendation (acknowledge on the dashboard to allow):\n${messages.join("\n")}`;
+        if (newQueryGate.conclusion === "failure") core.setFailed(message);
+        else core.warning(message);
       }
     }
   } finally {


### PR DESCRIPTION
Draft until @query-doctor/core 0.15.0 is on npm. Blocked on Query-Doctor/Site#3640, which adds the `new-query-index` default and publishes core 0.15.0. Until then the key falls back to `warn` and CI can't resolve the `^0.15.0` pin.

### Goal

Let a repo set the new-query CI gate to warn/off, like the regression and schema-drift arms already allow. Completes the policy-engine routing for the last inline gate.

### What

Before: a new query shipping with a beyond-threshold index recommendation blocks the check through an inline `core.setFailed`. A repo can't soften it.

After: the same case routes through `resolveVerdict` under the `new-query-index` key. It still blocks by default (the key defaults `fail` in core), but a repo can set it to `warn` (surfaced, non-blocking) or `off` (suppressed). Plain new queries are unaffected — they stay on `new-query`, which defaults `warn`. The message text and the acknowledge-to-allow behavior are unchanged.

### How

Read in this order:

- `src/gate/new-query.ts` — new `gateNewQuery(count, config)`, mirroring `gateRegression`. Returns the check outcome when there are eligible new queries and the policy surfaces them, else null.
- `src/main.ts` — the inline `if (gateNewQueries.length > 0) core.setFailed(...)` becomes `gateNewQuery(...)` + `setFailed`/`warning` on the resolved conclusion. `gateEligibleNewQueries` still scopes to the actionable set. The regression arm above it is untouched.
- `package.json` — core pin `^0.14.0 → ^0.15.0`.

### Tests

`src/gate/new-query.test.ts`: blocks by default, warn → neutral, off → null, none → null. Full suite run locally against a built core 0.15.0: 34 files, 330 tests green (including `site-api.test.ts`). Typecheck clean.