### PR TITLE
fix(gate): exempt below-minimumCost new queries from the index gate

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -337,6 +337,7 @@ async function runInCI(
         newQueries,
         config.regressionThreshold,
         config.acknowledgedQueryHashes,
+        config.minimumCost,
       );
       if (gateNewQueries.length > 0) {
         const messages = gateNewQueries.map((q) => {

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -270,6 +270,95 @@ describe("buildViewModel", () => {
     expect(vm.displayNewQueries).toHaveLength(0);
   });
 
+  test("a new query with a below-threshold recommendation is surfaced as a recommendation, not 'no index suggestion'", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        newQueries: [
+          {
+            hash: "cheap-new",
+            query: 'SELECT "id" FROM "projects"',
+            formattedQuery: 'SELECT "id" FROM "projects"',
+            nudges: [], tags: [], tableReferences: [],
+            optimization: {
+              state: "improvements_available",
+              cost: 13,
+              optimizedCost: 9,
+              costReductionPercentage: 30,
+              indexRecommendations: [
+                {
+                  schema: "public",
+                  table: "projects",
+                  columns: [{ schema: "public", table: "projects", column: "team_id" }],
+                  definition: "CREATE INDEX ON projects (team_id)",
+                },
+              ],
+              indexesUsed: [],
+            },
+          },
+        ],
+      }),
+      recommendations: [],
+      belowThresholdRecommendations: [
+        makeRecommendation({
+          fingerprint: "cheap-new",
+          formattedQuery: 'SELECT "id" FROM "projects"',
+          baseCost: 13,
+          optimizedCost: 9,
+        }),
+      ],
+    });
+    const vm = buildViewModel(ctx);
+
+    expect(vm.displayNewQueries).toHaveLength(0);
+    expect(vm.displayRecommendations.map((r) => r.fingerprint)).toEqual([
+      "cheap-new",
+    ]);
+    expect(vm.displayRecommendations[0].belowThreshold).toBe(true);
+  });
+
+  test("template shows a below-threshold new-query recommendation with a not-gated note", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        newQueries: [
+          {
+            hash: "cheap-new",
+            query: 'SELECT "id" FROM "projects"',
+            formattedQuery: 'SELECT "id" FROM "projects"',
+            nudges: [], tags: [], tableReferences: [],
+            optimization: {
+              state: "improvements_available",
+              cost: 13,
+              optimizedCost: 9,
+              costReductionPercentage: 30,
+              indexRecommendations: [
+                {
+                  schema: "public",
+                  table: "projects",
+                  columns: [{ schema: "public", table: "projects", column: "team_id" }],
+                  definition: "CREATE INDEX ON projects (team_id)",
+                },
+              ],
+              indexesUsed: [],
+            },
+          },
+        ],
+      }),
+      belowThresholdRecommendations: [
+        makeRecommendation({
+          fingerprint: "cheap-new",
+          formattedQuery: 'SELECT "id" FROM "projects"',
+          baseCost: 13,
+          optimizedCost: 9,
+        }),
+      ],
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain('SELECT "id" FROM "projects"');
+    expect(output).toContain("below cost threshold (not gated)");
+    expect(output).not.toContain("no index suggestion");
+  });
+
   test("template lists a new query that has no index suggestion", () => {
     const ctx = makeContext({
       comparison: makeComparison({

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -34,6 +34,8 @@ n.configure({ autoescape: false, trimBlocks: true, lstripBlocks: true });
 
 interface DisplayRecommendation extends ReportIndexRecommendation {
   queryPreview: string;
+  /** Below the `minimumCost` floor: shown for context, but does not gate the PR. */
+  belowThreshold: boolean;
 }
 
 interface DisplayRegression extends RegressedQuery {
@@ -70,10 +72,12 @@ export function queryPreview(formattedQuery: string): string {
 
 function addPreviews(
   recs: ReportIndexRecommendation[],
+  belowThreshold = false,
 ): DisplayRecommendation[] {
   return recs.map((r) => ({
     ...r,
     queryPreview: queryPreview(r.formattedQuery),
+    belowThreshold,
   }));
 }
 
@@ -172,10 +176,23 @@ export function buildViewModel(ctx: ReportContext) {
   const recommendedHashes = new Set(
     ctx.recommendations.map((r) => r.fingerprint),
   );
-
-  const displayRecommendations = addPreviews(
-    ctx.recommendations.filter((r) => newQueryHashes.has(r.fingerprint)),
+  // New queries whose recommendation is below the cost floor: shown with their
+  // fix, marked below-threshold, and NOT gated. Without this they'd fall through
+  // to displayNewQueries and be mislabeled "no index suggestion". Scoped to new
+  // queries — below-floor recommendations on pre-existing queries stay hidden.
+  const belowThresholdNewRecs = (ctx.belowThresholdRecommendations ?? []).filter(
+    (r) => newQueryHashes.has(r.fingerprint),
   );
+  const belowThresholdHashes = new Set(
+    belowThresholdNewRecs.map((r) => r.fingerprint),
+  );
+
+  const displayRecommendations = [
+    ...addPreviews(
+      ctx.recommendations.filter((r) => newQueryHashes.has(r.fingerprint)),
+    ),
+    ...addPreviews(belowThresholdNewRecs, true),
+  ];
   const preExistingRecommendations = addPreviews(
     ctx.recommendations.filter((r) => !newQueryHashes.has(r.fingerprint)),
   );
@@ -183,9 +200,12 @@ export function buildViewModel(ctx: ReportContext) {
   // New queries that carry no index recommendation are otherwise invisible:
   // counted in the "N new" tally but listed nowhere (Site#3287 follow-up). The
   // ones that DO have a recommendation already render under "introduces queries
-  // with recommendations", so exclude them here to avoid double-listing.
+  // with recommendations" (gated above the floor, below-threshold below it), so
+  // exclude both here to avoid double-listing.
   const displayNewQueries = addNewQueryPreviews(
-    ctx.comparison!.newQueries.filter((q) => !recommendedHashes.has(q.hash)),
+    ctx.comparison!.newQueries.filter(
+      (q) => !recommendedHashes.has(q.hash) && !belowThresholdHashes.has(q.hash),
+    ),
   );
 
   const displayRegressed = addRegressionPreviews(ctx.comparison!.regressed);

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -101,7 +101,7 @@
 
 {% for r in displayRecommendations %}
 {% set link = queryLinks[r.fingerprint] %}
-- {% if link %}[<code>{{ r.queryPreview }}</code>]({{ link }}){% else %}<code>{{ r.queryPreview }}</code>{% endif %}<br>recommended index <code>{{ r.proposedIndexes | join("</code>, <code>") }}</code><br>cost {{ formatCost(r.baseCost) }} → {{ formatCost(r.optimizedCost) }} ({{ (((r.baseCost - r.optimizedCost) / r.baseCost) * 100) | round(0) }}% reduction)
+- {% if link %}[<code>{{ r.queryPreview }}</code>]({{ link }}){% else %}<code>{{ r.queryPreview }}</code>{% endif %}<br>recommended index <code>{{ r.proposedIndexes | join("</code>, <code>") }}</code><br>cost {{ formatCost(r.baseCost) }} → {{ formatCost(r.optimizedCost) }} ({{ (((r.baseCost - r.optimizedCost) / r.baseCost) * 100) | round(0) }}% reduction){% if r.belowThreshold %} · below cost threshold (not gated){% endif %}{{""}}
 {% endfor %}
 {% endif %}
 

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -81,6 +81,13 @@ export interface ReportContext {
   statisticsMode: StatisticsMode;
   computedStats?: ComputedStats;
   recommendations: ReportIndexRecommendation[];
+  /**
+   * Recommendations dropped from `recommendations` because their `baseCost` is at
+   * or below the repo's `minimumCost` floor — too cheap to gate on, but still
+   * shown in the comment (marked below-threshold) so a below-floor query isn't
+   * mislabeled "no index suggestion". Empty when no floor is set.
+   */
+  belowThresholdRecommendations?: ReportIndexRecommendation[];
   queriesPastThreshold: ReportQueryCostWarning[];
   queryStats: Readonly<ReportStatistics>;
   statistics: [IndexIdentifier, IndexStatistic][];

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -534,6 +534,7 @@ describe("gateEligibleNewQueries", () => {
     hash: string,
     costReductionPercentage: number,
     hasIndexRecommendation = true,
+    cost = 407_000,
   ): CiQueryPayload {
     return {
       hash,
@@ -541,7 +542,7 @@ describe("gateEligibleNewQueries", () => {
       formattedQuery: "SELECT *\nFROM t\nWHERE user_id = $1",
       optimization: {
         state: "improvements_available",
-        cost: 407_000,
+        cost,
         optimizedCost: 8.2,
         costReductionPercentage,
         indexRecommendations: hasIndexRecommendation
@@ -603,6 +604,39 @@ describe("gateEligibleNewQueries", () => {
     );
 
     expect(result.map((q) => q.hash)).toEqual(["b"]);
+  });
+
+  test("does not gate a new query whose cost is at or below minimumCost", async () => {
+    const result = gateEligibleNewQueries(
+      [withRecommendation("a", 99, true, 80)],
+      90,
+      [],
+      100,
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("gates a new query whose cost exceeds minimumCost", async () => {
+    const result = gateEligibleNewQueries(
+      [withRecommendation("a", 99, true, 150)],
+      90,
+      [],
+      100,
+    );
+
+    expect(result.map((q) => q.hash)).toEqual(["a"]);
+  });
+
+  test("with minimumCost 0 the cost floor is disabled", async () => {
+    const result = gateEligibleNewQueries(
+      [withRecommendation("a", 99, true, 5)],
+      90,
+      [],
+      0,
+    );
+
+    expect(result.map((q) => q.hash)).toEqual(["a"]);
   });
 });
 

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -479,11 +479,18 @@ export async function compareRuns(
  * regression must exceed that same percentage. Acknowledged hashes are exempt,
  * the same triage escape hatch regressions have; ignored hashes never reach here
  * (they're dropped in {@link buildQueries}).
+ *
+ * `minimumCost` is the same cost floor the regressed/improved arms honor in
+ * {@link buildComparison}: a query at or below it is too cheap to gate on
+ * (a large percentage cut of a trivial cost is still a trivial saving), so it is
+ * excluded even when its recommendation clears the percentage threshold. `0`
+ * disables the floor.
  */
 export function gateEligibleNewQueries(
   newQueries: CiQueryPayload[],
   regressionThreshold: number,
   acknowledgedQueryHashes: string[] = [],
+  minimumCost = 0,
 ): CiQueryPayload[] {
   const acknowledgedSet = new Set(acknowledgedQueryHashes);
   return newQueries.filter((q) => {
@@ -492,7 +499,8 @@ export function gateEligibleNewQueries(
     return (
       opt.state === "improvements_available" &&
       opt.indexRecommendations.length > 0 &&
-      opt.costReductionPercentage > regressionThreshold
+      opt.costReductionPercentage > regressionThreshold &&
+      (minimumCost <= 0 || opt.cost > minimumCost)
     );
   });
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -185,12 +185,12 @@ export class Runner {
         : queriesPastThreshold;
 
     if (config.minimumCost > 0) {
-      const filtered =
-        recommendations.length - filteredRecommendations.length +
-        (queriesPastThreshold.length - filteredThresholdWarnings.length);
-      if (filtered > 0) {
+      const shownNotGated = belowThresholdRecommendations.length;
+      const filteredWarnings =
+        queriesPastThreshold.length - filteredThresholdWarnings.length;
+      if (shownNotGated > 0 || filteredWarnings > 0) {
         console.log(
-          `Filtered ${filtered} queries below minimumCost=${config.minimumCost} from PR comment`,
+          `minimumCost=${config.minimumCost}: ${shownNotGated} recommendation(s) shown below threshold (not gated), ${filteredWarnings} cost warning(s) filtered from the PR comment`,
         );
       }
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -172,6 +172,13 @@ export class Runner {
       config.minimumCost > 0
         ? recommendations.filter((r) => r.baseCost > config.minimumCost)
         : recommendations;
+    // Kept, not discarded: still shown in the comment (marked below-threshold) so
+    // a below-floor query isn't mislabeled "no index suggestion", but excluded
+    // from gating and index statistics.
+    const belowThresholdRecommendations =
+      config.minimumCost > 0
+        ? recommendations.filter((r) => r.baseCost <= config.minimumCost)
+        : [];
     const filteredThresholdWarnings =
       config.minimumCost > 0
         ? queriesPastThreshold.filter((w) => w.baseCost > config.minimumCost)
@@ -196,6 +203,7 @@ export class Runner {
       statisticsMode: this.remote.optimizer.statisticsMode,
       computedStats: this.remote.optimizer.computedStats,
       recommendations: filteredRecommendations,
+      belowThresholdRecommendations,
       queriesPastThreshold: filteredThresholdWarnings,
       queryStats: Object.freeze({
         analyzed,


### PR DESCRIPTION
### What

A new query with a trivial cost but a high-percentage index recommendation used to fail the CI gate while the PR comment showed no recommendation for it. Now the cost floor is applied consistently: below-floor new queries do not gate, and their recommendation still shows in the comment marked below-threshold.

Seen on [Query-Doctor/Site#3638](https://github.com/Query-Doctor/Site/pull/3638): three new queries at cost 13/17/13 (with a 30%/23%/30% index cut) failed the build, yet the comment listed each as `cost 13 · no index suggestion`. Same query, two answers — the comment said nothing to fix, the gate blocked the merge.

### Why it happened

The floor (`minimumCost`, 100 for that repo) was applied in two places but not a third:

- `buildComparison` skips regressed and improved queries when both costs are below the floor.
- `runner.ts` drops below-floor recommendations before the comment renders, so the comment can't tell the query has a recommendation and the template hardcodes "no index suggestion".
- `gateEligibleNewQueries` keyed only on the recommendation's cost-reduction percentage, never the floor — so it fired on the same query the comment had just suppressed.

### How

- `gateEligibleNewQueries` takes the `minimumCost` floor and excludes new queries at or below it (`opt.cost > minimumCost`), matching the regressed/improved arms. Wired through from `config.minimumCost` in `main.ts`.
- Below-floor recommendations are no longer discarded in `runner.ts`; they reach the comment as `belowThresholdRecommendations` on `ReportContext`.
- `buildViewModel` routes a below-floor new-query recommendation into the recommendations section flagged `belowThreshold`, and out of the plain new-query list, so it renders with its proposed index and a `· below cost threshold (not gated)` note instead of `no index suggestion`.
- The `minimumCost` log line no longer conflates the two below-floor buckets: recommendations are shown-but-not-gated, only cost warnings are filtered from the comment.

Reading order: `site-api.ts` (gate) → `main.ts` (caller) → `runner.ts` (partition) → `github.ts` + `success.md.j2` (comment).

### Scope note

The new-query arm still calls `core.setFailed` directly rather than routing through the `#3500` policy engine, so it can't be softened to warn/off repo-wide. That's a separate change and out of scope here.

### Tests

- `gateEligibleNewQueries`: a below-floor new query is not gated; an above-floor one still is; `minimumCost` 0 disables the floor.
- `buildViewModel`: a below-floor new-query recommendation lands in `displayRecommendations` flagged below-threshold and out of `displayNewQueries`.
- Template: renders the recommendation with the not-gated note and no "no index suggestion".
- Full suite 331 passing, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)