### PR TITLE
ci: bump actions/cache to v6 for the Node 24 runtime

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ runs:
 
     # Cache pgBadger build
     - name: Cache pgBadger
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: pgbadger-cache
       with:
         path: /usr/local/bin/pgbadger
@@ -64,7 +64,7 @@ runs:
         sudo chown -R $(whoami) /usr/lib/postgresql/${{ inputs.postgres-version }}
 
     - name: Cache postgresql-client
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: pg-client-cache
       with:
         path: /usr/lib/postgresql/${{ inputs.postgres-version }}


### PR DESCRIPTION
Consumers of this action see a Node 20 deprecation warning on every run, four times per job. This removes it.

## What

Before: a workflow using `query-doctor/analyzer` logs

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable.

once for each of the two cache steps, and once more for each of their post-job cleanups. After: no warning.

## How

`actions/cache@v4` declares `using: node20` in its `action.yml`. GitHub [deprecated that runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and now runs those actions on Node 24 anyway, with a warning. `v6` declares `using: node24`.

Both occurrences in `action.yaml` are bumped: the pgBadger cache at line 32 and the postgresql-client cache at line 67. Neither `v5` nor `v6` changed any input this action passes (`path`, `key`). Both majors were dependency upgrades and an ESM migration. The step definitions are otherwise untouched.

This is the last Node 20 action in the composite. `actions/setup-node@v6` already runs on Node 24.

## Tests

Not separately tested. The change is two version pins with no change to the input surface. Verification is the absence of the warning in a consumer's CI run against this branch.
