### PR TITLE
feat(reporters): surface modeled tables in the CI comment

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -975,3 +975,84 @@ describe("test-presence verdict rendering", () => {
     );
   });
 });
+
+describe("modeled-tables notice (Site#3420)", () => {
+  const MODELED_SENTENCE = "aren't covered by the statistics you loaded";
+
+  test("builds the notice on the comparison path", () => {
+    const vm = buildViewModel(
+      makeContext({
+        comparison: makeComparison(),
+        modeledTables: ["public.invoices"],
+      }),
+    );
+    expect(vm.modeledTablesNotice).toEqual({
+      count: 1,
+      list: "`public.invoices`",
+    });
+  });
+
+  // The no-baseline run is the one that matters: buildViewModel returns early
+  // for it from a separate object literal, so a field added only to the other
+  // return vanishes here — silently, and exactly where an unverified cost is
+  // most likely to read as a clean pass.
+  test("builds the notice on the non-comparison path too", () => {
+    const vm = buildViewModel(
+      makeContext({ modeledTables: ["public.invoices"] }),
+    );
+    expect(vm.hasComparison).toBe(false);
+    expect(vm.modeledTablesNotice).toEqual({
+      count: 1,
+      list: "`public.invoices`",
+    });
+  });
+
+  test("caps the list at ten names and counts the rest", () => {
+    const tables = Array.from({ length: 13 }, (_, i) => `public.t${i}`);
+    const vm = buildViewModel(makeContext({ modeledTables: tables }));
+    expect(vm.modeledTablesNotice?.count).toBe(13);
+    expect(vm.modeledTablesNotice?.list).toBe(
+      "`public.t0`, `public.t1`, `public.t2`, `public.t3`, `public.t4`, `public.t5`, `public.t6`, `public.t7`, `public.t8`, `public.t9`, and 3 more",
+    );
+  });
+
+  test("is null when the snapshot covers the whole schema", () => {
+    expect(buildViewModel(makeContext({ modeledTables: [] })).modeledTablesNotice).toBeNull();
+  });
+
+  test("is null when the run carries no modeled-tables list at all", () => {
+    expect(buildViewModel(makeContext()).modeledTablesNotice).toBeNull();
+  });
+
+  test("renders a non-blocking note naming the tables", () => {
+    const output = renderTemplate(
+      makeContext({
+        comparison: makeComparison(),
+        modeledTables: ["public.invoices", "public.line_items"],
+      }),
+    );
+    expect(output).toContain("[!NOTE]");
+    expect(output).not.toContain("[!CAUTION]");
+    expect(output).not.toContain("[!WARNING]");
+    expect(output).toContain(
+      "**2 table(s) in your schema aren't covered by the statistics you loaded**",
+    );
+    expect(output).toContain("`public.invoices`, `public.line_items`");
+    expect(output).toContain("A query touching one isn't a clean pass.");
+  });
+
+  test("renders the note on a run with no baseline", () => {
+    const output = renderTemplate(
+      makeContext({ modeledTables: ["public.invoices"] }),
+    );
+    expect(output).toContain(MODELED_SENTENCE);
+    expect(output).toContain("`public.invoices`");
+  });
+
+  test("renders nothing when there are no modeled tables", () => {
+    expect(renderTemplate(makeContext({ modeledTables: [] }))).not.toContain(
+      MODELED_SENTENCE,
+    );
+    expect(renderTemplate(makeContext())).not.toContain(MODELED_SENTENCE);
+  });
+});

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -54,6 +54,16 @@ interface DisplayNewQuery {
   costLabel: string;
 }
 
+/** Matches the cap in Site's `modeledTablesWarning` (mcp-server/src/apply-stats.ts). */
+const MODELED_TABLES_SHOWN = 10;
+
+interface ModeledTablesNotice {
+  /** Total modeled tables, including any beyond the cap. */
+  count: number;
+  /** Backticked names, capped, with a trailing "and N more" when truncated. */
+  list: string;
+}
+
 export function formatCost(cost: number): string {
   return Math.round(cost).toLocaleString("en-US");
 }
@@ -147,10 +157,35 @@ function buildSchemaChange(ctx: ReportContext): SchemaChangeView {
   return buildSchemaChangeView(change.operations);
 }
 
+/**
+ * Caveat for tables the production snapshot never saw: the synthesizer estimated
+ * their row counts, so costs touching them are modeled rather than measured. The
+ * cap and phrasing mirror `modeledTablesWarning` in Site's mcp-server so the CI
+ * comment and the MCP tools tell a developer the same thing.
+ *
+ * Named `modeledTablesNotice`, not `modeledTables`: the reporter renders with
+ * `{...ctx, ...viewModel}`, and reusing the key would shadow `ctx.modeledTables`
+ * with a different shape — correct only for as long as the spread order holds.
+ */
+function buildModeledTablesNotice(
+  ctx: ReportContext,
+): ModeledTablesNotice | null {
+  const tables = ctx.modeledTables ?? [];
+  if (tables.length === 0) return null;
+  const shown = tables.slice(0, MODELED_TABLES_SHOWN);
+  const rest = tables.length - shown.length;
+  const names = shown.map((t) => `\`${t}\``).join(", ");
+  return {
+    count: tables.length,
+    list: rest > 0 ? `${names}, and ${rest} more` : names,
+  };
+}
+
 export function buildViewModel(ctx: ReportContext) {
   const hasComparison = !!ctx.comparison;
   const queryLinks = buildQueryLinks(ctx);
   const schemaChange = buildSchemaChange(ctx);
+  const modeledTablesNotice = buildModeledTablesNotice(ctx);
 
   if (!hasComparison) {
     return {
@@ -167,6 +202,7 @@ export function buildViewModel(ctx: ReportContext) {
       schemaChange,
       schemaChangeHeading,
       schemaChangeLabel,
+      modeledTablesNotice,
     };
   }
 
@@ -230,6 +266,7 @@ export function buildViewModel(ctx: ReportContext) {
     schemaChange,
     schemaChangeHeading,
     schemaChangeLabel,
+    modeledTablesNotice,
   };
 }
 

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -37,6 +37,11 @@
 > _{{ testPresenceVerdict.triageHint }}_
 
 {% endif %}
+{% if modeledTablesNotice %}
+> [!NOTE]
+> **{{ modeledTablesNotice.count }} table(s) in your schema aren't covered by the statistics you loaded**, so their costs are modeled, not verified against real data: {{ modeledTablesNotice.list }}. A query touching one isn't a clean pass.
+
+{% endif %}
 {% if hasComparison %}
 {{ queryStats.analyzed | default('?') }} queries analyzed
 {% elif comparisonUnavailable %}

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -134,7 +134,7 @@ export interface ReportContext {
    * Tables ("schema.table") in the analyzed schema the production snapshot
    * doesn't cover, so their costs were modeled by the synthesizer rather than
    * verified against real data. Empty when the snapshot covers the whole schema.
-   * Not yet rendered in the comment — plumbed for the surfacing that follows.
+   * Rendered as a non-blocking note at the top of the GitHub comment.
    */
   modeledTables?: string[];
 }


### PR DESCRIPTION
## Goal

A developer reading a Query Doctor PR comment should be able to tell a measured cost from an estimated one. Costs are planned against a snapshot of production statistics; a table the snapshot has never seen has no real row count, so the synthesizer estimates one. Those estimates are plausible, not measured, and a query against such a table can pass the gate for the wrong reason.

This is the reporting half of [Site#3420](https://github.com/Query-Doctor/Site/issues/3420). The data half merged in #184. The MCP tools already carry the caveat; this brings the CI comment in line. No follow-up is planned after this — see the note at the bottom for a separate item this uncovered.

## What

Before: a PR touching a table the snapshot doesn't cover showed its cost with no indication the number was estimated.

After: the comment opens with a note naming those tables.

> [!NOTE]
> **1 table(s) in your schema aren't covered by the statistics you loaded**, so their costs are modeled, not verified against real data: `public.invoices`. A query touching one isn't a clean pass.

Nothing renders when the snapshot covers the whole schema. Nothing gates on it — the severity is `NOTE`, not `CAUTION`, so it must not read as a blocking error.

## How

Read `src/reporters/github/github.ts` first. `buildModeledTablesNotice(ctx)` turns `ReportContext.modeledTables` into `{count, list}`, or `null` when the list is empty, and the template renders on that single truthy check. The wording and the ten-name `and N more` cap are copied from `modeledTablesWarning` in Site's `packages/mcp-server/src/apply-stats.ts`, so the CI comment and the MCP tools tell a developer the same thing.

Two decisions worth flagging:

**The field is named `modeledTablesNotice`, not `modeledTables`.** `report()` renders with `{...ctx, ...viewModel}`, so `ctx.modeledTables` is already in template scope. Reusing the key would shadow a `string[]` with an object, which works only as long as viewModel keeps spreading second.

**`buildViewModel` has two return statements**, and the early one covers runs with no baseline. A field added to one and not the other vanishes silently on exactly those runs — it compiles, it type-checks, and it produces the false all-clear this work exists to remove. Both returns carry the field, and a test pins the no-baseline path on its own. The same shape of bug hit the Site side once already (`ac5c73c72`).

`src/reporters/reporter.ts` has a one-line doc fix: the comment on `modeledTables` claimed the field wasn't rendered yet.

## Tests

Eight tests in `github.test.ts`. On the view model: the comparison path, the no-baseline path, the ten-name cap with `and 3 more`, an empty list, and an absent list. On the template: the note renders with a `NOTE` severity and never `CAUTION` or `WARNING`, it renders on a run with no baseline, and it renders nothing when there are no modeled tables.

The existing snapshots are unchanged rather than regenerated. Neither sets `modeledTables`, so nothing new renders for them; leaving them untouched proves this didn't disturb unrelated output.

Full suite passes (344 tests, 35 files). `tsc --noEmit` is clean.

Beyond the suite, I rendered the real `success.md.j2` through the real `buildViewModel`, using the same spread order `report()` uses, across four contexts: with a baseline, without one, with 13 tables, and with none. Output matched in all four.

**Not verified:** no live CI run against a branch that adds an uncovered table. Everything upstream of `ReportContext.modeledTables` is trusted on #184 having merged, not observed here. Worth a `qa-setup-ci` pass against a throwaway migration before this is relied on.

## Not in this PR

`Statistics`'s optional fifth constructor argument: synthesis only runs when a caller passes `currentSchema`, and `Statistics.fromPostgres` can't pass it, so some paths never synthesize at all. Core `0.16.0` is published and this repo now calls the constructor positionally, so changing that shape is a coordinated break across two repos. It should be done deliberately and separately.
