### PR TITLE
refact: adopt the Statistics construction factories from core 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.16.0",
+        "@query-doctor/core": "^0.17.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-7J/W5tz76g3U70kSaBU3cTTCqFQ1Bmu+PqUSJBf9mlvL9WAbwWxJoa+eL90dNmLuyAyjEG6Gzf8QDFc0Qd8hwA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-WN0so5G6dqmOx0v7NGw58nTbTlIXdX/eTHRIyxSP/uBLPGfYPmTna3B+o4s2KixA7uVez5uaCM//1KhJ36r/Ww==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.16.0",
+    "@query-doctor/core": "^0.17.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/remote/query-optimizer.ts
+++ b/src/remote/query-optimizer.ts
@@ -155,11 +155,27 @@ export class QueryOptimizer extends EventEmitter<EventMap> {
     const version = PostgresVersion.parse("17");
     const pg = this.manager.getOrCreateConnection(this.connectable);
     const ownStats = await Statistics.dumpStats(pg, version);
-    // Pass the current schema so tables the exported snapshot doesn't cover
-    // (added on this branch / since the snapshot was captured) are sized by the
-    // synthesizer instead of the flat default. No-op when statsMode isn't
-    // fromStatisticsExport.
-    const statistics = new Statistics(pg, version, ownStats, statsMode, schema);
+    // The current schema lets tables the exported snapshot doesn't cover — added
+    // on this branch, or since the snapshot was captured — be sized by the
+    // synthesizer instead of a flat default.
+    const statistics =
+      statsMode.kind === "fromStatisticsExport"
+        ? Statistics.forExport({
+            postgresVersion: version,
+            plannerTables: ownStats,
+            snapshot: statsMode.stats,
+            // Absent only before the first schema sync. An empty schema gives
+            // the synthesizer nothing to size, so those tables keep the default.
+            schema: schema ?? FullSchema.parse({}),
+            scale: statsMode.scale,
+            source: statsMode.source,
+          })
+        : Statistics.forAssumption({
+            postgresVersion: version,
+            plannerTables: ownStats,
+            reltuples: statsMode.reltuples,
+            scale: statsMode.scale,
+          });
     this.existingIndexes = schema?.indexes ?? [];
     const filteredIndexes = this.filterDisabledIndexes(this.existingIndexes);
     const optimizer = new IndexOptimizer(pg, statistics, filteredIndexes, {


### PR DESCRIPTION
### Goal

Query-Doctor/Site#3668 made `Statistics` require the current schema when costing against an exported snapshot, so a table the snapshot doesn't cover can no longer be silently costed at a flat default. This adopts that API here.

> **Draft until `@query-doctor/core@0.17.0` is on npm.** It publishes from the Site merge that just landed. Until then `npm install` can't resolve the range and CI is red — expected.

### What

No behavior change on the paths that already worked. The connected and CI costing paths keep synthesizing exactly as before; this is the same call expressed through the new entry points.

### How

`src/remote/query-optimizer.ts` — `setStatistics` branches on the mode and calls the matching factory:

- `fromStatisticsExport` → `Statistics.forExport({ postgresVersion, plannerTables, snapshot, schema, scale, source })`
- `fromAssumption` → `Statistics.forAssumption({ postgresVersion, plannerTables, reltuples, scale })`

`schema` is optional on `setStatistics` — it's absent before the first schema sync — and `forExport` requires one. That case passes an empty schema, which gives the synthesizer nothing to size and leaves those tables on the default estimate, matching today's behavior.

This is the only `Statistics` construction in the repo.

### Sequencing

1. Site#3668 merged → core `0.17.0` publishes.
2. Here: `npm install` to sync the lockfile, mark ready, CI goes green.

### Tests

Existing suite; no new cases. The change is a call-shape migration, and `query-optimizer-synthesis.test.ts` already covers that `setStatistics` forwards the schema and that `syntheticTables` reports uncovered tables.