### PR TITLE
feat(remote): re-dump production statistics when the source drifts

### DIFF
--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -22,6 +22,11 @@ import { EventEmitter } from "node:events";
 import { log } from "../log.ts";
 import { QueryLoader } from "./query-loader.ts";
 import { SchemaLoader } from "./schema-loader.ts";
+import {
+  baselineFromDump,
+  detectDrift,
+  type StatsBaseline,
+} from "./stats-drift.ts";
 
 type RemoteEvents = {
   dumpLog: [line: string];
@@ -77,6 +82,16 @@ export class Remote extends EventEmitter<RemoteEvents> {
   private isPolling = false;
   private queryLoader?: QueryLoader;
   private schemaLoader?: SchemaLoader;
+  /**
+   * Tables and row counts as of the last statistics dump this analyzer pushed.
+   * Drift is measured against this, not against the previous poll, so a slow
+   * steady change still eventually earns a re-dump (ADR 0007 §2). Undefined
+   * until the first push, and only maintained for `fromSource` stats — an
+   * imported or synthetic snapshot has no live baseline to drift against.
+   */
+  private statsBaseline?: StatsBaseline;
+  /** Guards against a second drift dump starting while one is in flight. */
+  private refreshingStats = false;
   private pgStatStatementsStatus: PgStatStatementsStatus =
     PgStatStatementsStatus.Unknown;
 
@@ -359,6 +374,40 @@ export class Remote extends EventEmitter<RemoteEvents> {
     return { mode: await this.dumpSourceStats(source), strategy: "fromSource" };
   }
 
+  /**
+   * Re-dump and push the source's statistics when they've drifted far enough
+   * from what we last pushed (ADR 0007 §2). Runs on the schema poll tick.
+   *
+   * No-ops until a `fromSource` dump has established a baseline: a synthetic or
+   * imported snapshot has nothing meaningful to drift against, and inventing a
+   * baseline for it would push someone else's numbers as this project's
+   * production statistics.
+   */
+  private async refreshStatsIfDrifted(source: Connectable): Promise<void> {
+    if (!this.statsBaseline || this.refreshingStats) {
+      return;
+    }
+    const connector = this.sourceManager.getConnectorFor(source);
+    const reltuples = await connector.getReltuplesByTable();
+    const verdict = detectDrift(this.statsBaseline, { reltuples });
+    if (!verdict.drifted) {
+      return;
+    }
+
+    this.refreshingStats = true;
+    try {
+      log.info(
+        `${verdict.kind === "shape" ? "Shape" : "Size"} Drift — ${verdict.reason}. Re-dumping production statistics`,
+        "remote",
+      );
+      // applyStatistics records the new baseline and emits `statsApplied`,
+      // which is what carries the dump back to the server.
+      await this.applyStatistics(await this.dumpSourceStats(source));
+    } finally {
+      this.refreshingStats = false;
+    }
+  }
+
   private async dumpSourceStats(source: Connectable): Promise<StatisticsMode> {
     const pg = this.sourceManager.getOrCreateConnection(
       source,
@@ -391,6 +440,12 @@ export class Remote extends EventEmitter<RemoteEvents> {
     await this.optimizer.setStatistics(statsMode);
     const stats = this.optimizer.ownMetadata;
     if (stats) {
+      // Record what we're about to push as the drift baseline. Only meaningful
+      // for source-derived stats; an imported snapshot describes someone else's
+      // database, so drifting against it would be nonsense.
+      if (statsMode.kind === "fromStatisticsExport") {
+        this.statsBaseline = baselineFromDump(stats);
+      }
       this.emit("statsApplied", stats);
     }
     // don't block the reply by awaiting all optimizations
@@ -437,6 +492,14 @@ export class Remote extends EventEmitter<RemoteEvents> {
     this.schemaLoader = new SchemaLoader(this.sourceManager, source);
     this.schemaLoader.on("diff", (diffs, schema) => {
       this.emit("schemaDiffed", diffs, schema);
+    });
+    // The schema poll is also the drift tick: it already runs every 60s, so
+    // checking here costs one `pg_class` read and no extra schedule.
+    this.schemaLoader.on("polled", () => {
+      this.refreshStatsIfDrifted(source).catch((error) => {
+        log.error("Failed to check statistics drift", "remote");
+        console.error(error);
+      });
     });
     this.schemaLoader.on("pollError", (error) => {
       log.error("Failed to poll schema", "remote");

--- a/src/remote/schema-loader.ts
+++ b/src/remote/schema-loader.ts
@@ -8,6 +8,12 @@ import type { MetadataLoader, MetadataLoaderEvents } from "./metadata-loader.ts"
 
 export type SchemaLoaderEvents = MetadataLoaderEvents & {
   diff: [diffs: Op[], schema: FullSchema];
+  /**
+   * Emitted after every successful poll, whether or not the schema changed.
+   * Statistics drift rides this tick: row counts move without the schema
+   * moving, so `diff` alone would miss Size Drift entirely.
+   */
+  polled: [schema: FullSchema];
 };
 
 export class SchemaLoader extends EventEmitter<SchemaLoaderEvents>
@@ -75,6 +81,9 @@ export class SchemaLoader extends EventEmitter<SchemaLoaderEvents>
       this.consecutiveErrors = 0;
       if (diffs.length > 0 && this.latestSchema) {
         this.emit("diff", diffs, this.latestSchema);
+      }
+      if (this.latestSchema) {
+        this.emit("polled", this.latestSchema);
       }
     } catch (error) {
       this.consecutiveErrors++;

--- a/src/remote/stats-drift.test.ts
+++ b/src/remote/stats-drift.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { ExportedStats } from "@query-doctor/core";
+import {
+  baselineFromDump,
+  detectDrift,
+  SIZE_DRIFT_MIN_ROWS,
+} from "./stats-drift.ts";
+
+function table(name: string, reltuples: number): ExportedStats {
+  return {
+    schemaName: "public",
+    tableName: name,
+    reltuples,
+    relpages: Math.max(1, Math.round(reltuples / 100)),
+    relallvisible: 0,
+    columns: [],
+    indexes: [],
+  } as unknown as ExportedStats;
+}
+
+function reltuples(entries: Record<string, number>): Map<string, number> {
+  return new Map(
+    Object.entries(entries).map(([name, rows]) => [`public.${name}`, rows]),
+  );
+}
+
+const BIG = SIZE_DRIFT_MIN_ROWS * 10;
+
+describe("detectDrift — Shape Drift", () => {
+  it("fires when the source has a table the snapshot doesn't cover", () => {
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG, teams: 0 }),
+    });
+
+    expect(verdict.drifted).toBe(true);
+    if (!verdict.drifted) return;
+    expect(verdict.kind).toBe("shape");
+    expect(verdict.reason).toContain("public.teams");
+  });
+
+  it("fires for a brand-new empty table — the case a migration creates", () => {
+    // The table has 0 rows, so Size Drift would never see it. This is the
+    // exact miss that left six tables uncovered for six weeks.
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG, oauth_tokens: 0 }),
+    });
+
+    expect(verdict.drifted).toBe(true);
+    if (!verdict.drifted) return;
+    expect(verdict.kind).toBe("shape");
+  });
+
+  it("fires when a covered table is dropped", () => {
+    const baseline = baselineFromDump([
+      table("users", BIG),
+      table("legacy", BIG),
+    ]);
+
+    const verdict = detectDrift(baseline, { reltuples: reltuples({ users: BIG }) });
+
+    expect(verdict.drifted).toBe(true);
+    if (!verdict.drifted) return;
+    expect(verdict.kind).toBe("shape");
+    expect(verdict.reason).toContain("public.legacy");
+  });
+
+  it("takes precedence over a simultaneous size change", () => {
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG * 10, teams: 0 }),
+    });
+
+    if (!verdict.drifted) throw new Error("expected drift");
+    expect(verdict.kind).toBe("shape");
+  });
+});
+
+describe("detectDrift — Size Drift", () => {
+  it("fires when a table grows past the ratio", () => {
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG * 2 }),
+    });
+
+    expect(verdict.drifted).toBe(true);
+    if (!verdict.drifted) return;
+    expect(verdict.kind).toBe("size");
+    expect(verdict.reason).toContain("public.users");
+  });
+
+  it("fires when a table shrinks past the ratio", () => {
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG / 4 }),
+    });
+
+    expect(verdict.drifted).toBe(true);
+  });
+
+  it("ignores a move below the ratio", () => {
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: Math.round(BIG * 1.2) }),
+    });
+
+    expect(verdict.drifted).toBe(false);
+  });
+
+  it("ignores large ratios on tables that are tiny on both sides", () => {
+    // 2 -> 8 rows is +300% and means nothing to the planner. Without the floor
+    // this would re-dump on essentially every poll.
+    const baseline = baselineFromDump([table("flags", 2)]);
+
+    const verdict = detectDrift(baseline, { reltuples: reltuples({ flags: 8 }) });
+
+    expect(verdict.drifted).toBe(false);
+  });
+
+  it("still fires when a small table grows past the floor", () => {
+    const baseline = baselineFromDump([table("events", 10)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ events: BIG }),
+    });
+
+    expect(verdict.drifted).toBe(true);
+    if (!verdict.drifted) return;
+    expect(verdict.kind).toBe("size");
+  });
+
+  it("does not fire on an unchanged database", () => {
+    const baseline = baselineFromDump([
+      table("users", BIG),
+      table("orders", BIG * 3),
+    ]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG, orders: BIG * 3 }),
+    });
+
+    expect(verdict.drifted).toBe(false);
+  });
+});

--- a/src/remote/stats-drift.ts
+++ b/src/remote/stats-drift.ts
@@ -1,0 +1,145 @@
+import type { ExportedStats } from "@query-doctor/core";
+
+/**
+ * Decides when the production-statistics snapshot the server holds has fallen
+ * far enough behind the source database to be worth re-dumping (ADR 0007 §2).
+ *
+ * The full `DUMP_STATS_SQL` is expensive, so it is earned by detected change
+ * rather than run on a timer. Two signals, both cheap:
+ *
+ * - **Shape Drift** — the source has tables the last pushed dump doesn't cover,
+ *   or has dropped tables it did. Free: the analyzer already polls the schema
+ *   every 60s, so this is a set comparison with no extra query.
+ * - **Size Drift** — per-table `reltuples` have moved past a threshold. Costs
+ *   one `pg_class` read; never touches `pg_statistic`.
+ *
+ * Shape Drift is the one that matters most in practice: a table added by a
+ * migration has no stats at all, so every query touching it is costed by the
+ * synthesizer instead of real data until the snapshot catches up.
+ */
+
+/** A table's identity in a dump, as `"schema.table"`. */
+export type TableKey = string;
+
+export interface StatsBaseline {
+  /** Tables the last pushed dump covered. */
+  tables: Set<TableKey>;
+  /** Their `reltuples` at that moment, for the Size Drift comparison. */
+  reltuples: Map<TableKey, number>;
+}
+
+/** The current cheap reading from the source, for comparison against a baseline. */
+export interface SourceReltuples {
+  reltuples: Map<TableKey, number>;
+}
+
+export type DriftVerdict =
+  | { drifted: false }
+  | { drifted: true; kind: "shape" | "size"; reason: string };
+
+/**
+ * Ratio a table's `reltuples` must move by before Size Drift fires. 0.5 means
+ * the table has to halve or grow by 50%; below that the planner's choices are
+ * unlikely to change enough to be worth a full dump.
+ */
+export const DEFAULT_SIZE_DRIFT_RATIO = 0.5;
+
+/**
+ * Tables smaller than this are exempt from Size Drift. A table going from 2 to
+ * 4 rows is a 100% move and means nothing to the planner; without this floor a
+ * nearly-empty table would trigger a dump on every poll.
+ */
+export const SIZE_DRIFT_MIN_ROWS = 1_000;
+
+export function baselineFromDump(stats: ExportedStats[]): StatsBaseline {
+  const tables = new Set<TableKey>();
+  const reltuples = new Map<TableKey, number>();
+  for (const table of stats) {
+    const key = tableKey(table.schemaName, table.tableName);
+    tables.add(key);
+    reltuples.set(key, table.reltuples);
+  }
+  return { tables, reltuples };
+}
+
+export function tableKey(
+  schemaName: string | { toString(): string },
+  tableName: string | { toString(): string },
+): TableKey {
+  return `${unquote(String(schemaName))}.${unquote(String(tableName))}`;
+}
+
+function unquote(identifier: string): string {
+  return identifier.startsWith('"') && identifier.endsWith('"')
+    ? identifier.slice(1, -1)
+    : identifier;
+}
+
+/**
+ * Compares the source's current table set and row counts against the last dump
+ * that was pushed. Shape Drift is checked first: it's free, and a table with no
+ * stats at all is a worse problem than one whose count moved.
+ */
+export function detectDrift(
+  baseline: StatsBaseline,
+  current: SourceReltuples,
+  options?: { sizeDriftRatio?: number; minRows?: number },
+): DriftVerdict {
+  const ratio = options?.sizeDriftRatio ?? DEFAULT_SIZE_DRIFT_RATIO;
+  const minRows = options?.minRows ?? SIZE_DRIFT_MIN_ROWS;
+
+  const added: TableKey[] = [];
+  for (const key of current.reltuples.keys()) {
+    if (!baseline.tables.has(key)) added.push(key);
+  }
+  if (added.length > 0) {
+    return {
+      drifted: true,
+      kind: "shape",
+      reason: `${added.length} table(s) not covered by the snapshot: ${
+        summarize(added)
+      }`,
+    };
+  }
+
+  const dropped: TableKey[] = [];
+  for (const key of baseline.tables) {
+    if (!current.reltuples.has(key)) dropped.push(key);
+  }
+  if (dropped.length > 0) {
+    return {
+      drifted: true,
+      kind: "shape",
+      reason: `${dropped.length} table(s) in the snapshot no longer exist: ${
+        summarize(dropped)
+      }`,
+    };
+  }
+
+  for (const [key, now] of current.reltuples) {
+    const before = baseline.reltuples.get(key);
+    if (before === undefined) continue;
+    // Exempt tables that are small on both sides. A table that grew past the
+    // floor is a real change even if it started tiny.
+    if (before < minRows && now < minRows) continue;
+    const denominator = Math.max(before, 1);
+    const moved = Math.abs(now - before) / denominator;
+    if (moved >= ratio) {
+      return {
+        drifted: true,
+        kind: "size",
+        reason: `${key} moved from ${before} to ${now} rows (${
+          Math.round(moved * 100)
+        }%)`,
+      };
+    }
+  }
+
+  return { drifted: false };
+}
+
+function summarize(keys: TableKey[]): string {
+  const shown = keys.slice(0, 5);
+  const rest = keys.length - shown.length;
+  return rest > 0 ? `${shown.join(", ")}, and ${rest} more` : shown.join(", ");
+}

--- a/src/sync/pg-connector.ts
+++ b/src/sync/pg-connector.ts
@@ -407,6 +407,36 @@ ORDER BY
     return `${value.table}:${value.data[ctidSymbol]}` as Hash;
   }
 
+  /**
+   * Per-table `reltuples` for every user table, keyed `"schema.table"`.
+   *
+   * The Size/Shape Drift probe (ADR 0007 §2). Reads `pg_class` only — never
+   * `pg_statistic` — so it is cheap enough to fold into the 60s schema poll,
+   * unlike the full statistics dump it decides whether to run.
+   */
+  public async getReltuplesByTable(): Promise<Map<string, number>> {
+    const results = await this.db.exec<{
+      schema_name: string;
+      table_name: string;
+      reltuples: string;
+    }>(
+      `SELECT n.nspname AS schema_name, c.relname AS table_name, c.reltuples::bigint AS reltuples
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE c.relkind = 'r'
+         AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'tiger', 'tiger_data', 'topology')
+         AND c.relname NOT IN ('pg_stat_statements', 'pg_stat_statements_info')`,
+    );
+    const byTable = new Map<string, number>();
+    for (const row of results) {
+      // A never-analyzed table reports -1; treat it as 0 so it doesn't read as
+      // a size change on the next poll.
+      const reltuples = Math.max(0, Number(row.reltuples));
+      byTable.set(`${row.schema_name}.${row.table_name}`, reltuples);
+    }
+    return byTable;
+  }
+
   public async getTotalRowCount(
     tables: { schemaName: PgIdentifier; tableName: PgIdentifier }[],
   ): Promise<number> {


### PR DESCRIPTION
### Goal

Production Statistics go stale and nothing notices. Query Doctor's own snapshot was six weeks old: every table added since 2026-06-17 was missing from it, so queries touching those tables were costed by the synthesizer rather than real data. This implements the refresh half of ADR 0007 §2.

### What

Before, a stats dump reached the server only when something explicitly asked for one. The two callers of `applyStatistics` are `updateStatistics` and `resetStats`, and neither runs on a schedule. A long-lived analyzer pushed once and never again.

After, the analyzer re-dumps and pushes on its own when the source has moved far enough from what it last sent.

### How

Read `src/remote/stats-drift.ts` first. It holds the decision as two pure functions over a baseline, so the policy is testable without a database.

Two signals, both cheap:

- **Shape Drift**: the source has tables the last pushed dump doesn't cover, or dropped ones it did. This is a set comparison on data already in hand, so it costs nothing.
- **Size Drift**: a table's `reltuples` moved past a ratio. This reads `pg_class` and never touches `pg_statistic`.

Shape Drift is checked first. A table a migration just created has zero rows, so a size comparison would never see it. That is how the six tables were missed.

The check rides the existing 60s schema poll rather than adding a schedule. `SchemaLoader` gains a `polled` event that fires on every successful poll, not just when the schema changed, because row counts move while the schema stands still. On a drift verdict, `Remote` dumps from source and calls `applyStatistics`, which reuses the existing `statsApplied` to `pushStats` path.

Two guards worth knowing:

- The baseline is only recorded for `fromStatisticsExport` stats, so an imported or synthetic snapshot never arms drift. Drifting against someone else's numbers would push them as this project's production statistics.
- A `refreshingStats` flag stops a second dump starting while one is in flight.

Size Drift exempts tables under 1,000 rows on both sides. A table going from 2 rows to 8 is a 300% move and means nothing to the planner; without the floor it would re-dump on nearly every poll.

### Deliberately not here

The daily cron backstop in Site for analyzers that were asleep, and surfacing snapshot age in the app. Both are Site-side and independent.

### Tests

`stats-drift.test.ts` covers both signals: new table, new *empty* table, dropped table, shape taking precedence over size, growth and shrink past the ratio, a move under it, the small-table floor, a small table growing past the floor, and an unchanged database. Ten cases, no container needed.

### Snapshot Age already exists — this is the other two axes

`CONTEXT.md` names three ways a snapshot goes stale. Only one was built before this PR:

- **Snapshot Age** — built. `assessDumpFreshness()` in `packages/mcp-server/src/stats-dump-format.ts` warns when a dump is over 30 days old. It is `mcp-server` only, nothing in `apps/` or `packages/core` imports it, and it warns rather than triggering a refresh.
- **Shape Drift** — this PR.
- **Size Drift** — this PR.

Age is a proxy and a weak one. A snapshot two days old already misses a table a migration created that morning, which is the case that left six tables uncovered on the Query Doctor project. Shape Drift catches it; age does not.

Keeping the three named separately so a later change doesn't reimplement age detection under a drift name.
