### PR TITLE
fix(action): let Docker assign the Postgres host port

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -84,14 +84,15 @@ runs:
     - name: Start PostgreSQL
       shell: bash
       run: |
-        PORT=$(shuf -i 10000-65000 -n 1)
-        echo "PG_PORT=$PORT" >> $GITHUB_ENV
         echo "PG_DUMP_BINARY=/usr/lib/postgresql/${{ inputs.postgres-version }}/bin/pg_dump" >> $GITHUB_ENV
         echo "PG_RESTORE_BINARY=/usr/lib/postgresql/${{ inputs.postgres-version }}/bin/pg_restore" >> $GITHUB_ENV
+        # An empty host port makes the kernel pick a free one and bind it in the
+        # same operation, so nothing can claim it in between.
         docker run -d \
           --name query-doctor-postgres \
-          -p $PORT:5432 \
+          -p 127.0.0.1::5432 \
           ghcr.io/query-doctor/postgres:pg-${{ inputs.postgres-version }}
+        echo "PG_PORT=$(docker port query-doctor-postgres 5432/tcp | sed -n '1s/.*://p')" >> $GITHUB_ENV
         until docker exec query-doctor-postgres pg_isready -U postgres; do
           sleep 1
         done


### PR DESCRIPTION
A consumer's CI run failed today before the analyzer started:

> docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint query-doctor-postgres: failed to bind host port for 0.0.0.0:35682:172.17.0.2:5432/tcp: address already in use

This removes the guess that causes it.

## What

Before: the **Start PostgreSQL** step draws a host port with `shuf -i 10000-65000 -n 1` and hands it to `docker run -p`. If anything on the runner already holds that number, the container never starts and the step dies with exit 125. The **Run Analyzer** step never runs, so the consumer gets a failed check with no analysis in it. A re-run is the only remedy.

After: nothing picks a number, so nothing can collide.

## How

`10000-65000` overlaps the kernel's ephemeral port range, 32768–60999 by default. Linux draws local ports from that range for outbound connections, so about half of all picks land in territory the kernel hands out. By this step the job has opened many such connections: `npm ci`, the image pull, and the consumer's own earlier steps. Now and then the number comes up while a socket still holds it.

A check-then-bind retry loop narrows that window without closing it. Between "is this port free?" and `docker run`, the kernel can still hand the port out. Leaving the host port empty (`-p 127.0.0.1::5432`) closes it. Docker asks the kernel for a free port and binds it in one operation, and `docker port` reads back the result. `PG_PORT` moves below `docker run` because the port is now discovered, not decided.

The bind narrows from `0.0.0.0` to `127.0.0.1`. The only consumer is `POSTGRES_URL` on the next step, which connects over `localhost`. Both forms are IPv4-only, so nothing that reached the container before loses access.

`sed -n '1s/.*://p'` parses the port instead of `head -1 | sed`. The step runs under `-o pipefail`, where `head` closing the pipe early can fail the step.

## Tests

I ran the modified step body against `ghcr.io/query-doctor/postgres:pg-18`, under the shell GitHub uses for `shell: bash`: `bash --noprofile --norc -e -o pipefail`. It exits 0, writes `PG_PORT=52613` to `$GITHUB_ENV`, and `pg_isready` reports accepting connections. A TCP connection from the host reached both `127.0.0.1:52613` and `localhost:52613`, so the narrowed bind still serves the URL the next step builds.

This repo's own `test-run` job also covers it, since it runs the composite action with `uses: ./`. On this branch it passed, and the **Run Analyzer** step received `PG_PORT: 32768` from `docker port` rather than from `shuf`.
