### PR TITLE
feat(remote): seed the drift baseline from the stored snapshot on connect

### DIFF
--- a/src/remote/api-client.ts
+++ b/src/remote/api-client.ts
@@ -134,6 +134,24 @@ export class ApiClient extends RpcTarget implements ClientApi {
         });
         log.info(`Connected to the api`, this.#name);
         cleanup = hookUpApiReporter(api, remote);
+        // Adopt the stored snapshot as the drift baseline so a stale one gets
+        // refreshed on the next schema poll. Without this, drift only ever
+        // arms for analyzers that already pushed once in this process.
+        api.getProductionStats().then((stats) => {
+          if (!stats || stats.length === 0) return;
+          remote.seedStatsBaseline(stats);
+          log.info(
+            `Seeded the statistics drift baseline from the stored snapshot (${stats.length} tables)`,
+            this.#name,
+          );
+        }).catch((err) => {
+          // Non-fatal. Drift stays inert until a local dump sets a baseline,
+          // which is the behaviour before this seeding existed.
+          log.warn(
+            `Could not seed the statistics drift baseline: ${err}`,
+            this.#name,
+          );
+        });
       } catch (err) {
         if (err instanceof Error && err.message === "Unauthorized") {
           log.error(`Invalid TOKEN, cannot connect to the api`, this.#name);

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -436,6 +436,28 @@ export class Remote extends EventEmitter<RemoteEvents> {
     return connector.getDatabaseInfo();
   }
 
+  /**
+   * Adopt the server's stored snapshot as the drift baseline, without pushing.
+   *
+   * Drift is measured against the last dump this process pushed, so an analyzer
+   * that has never pushed has no baseline and never drifts — which is every
+   * project whose snapshot was seeded by hand. Seeding on connect closes that
+   * gap: the first schema poll can then compare the live schema against what
+   * the server holds and re-dump if it has fallen behind.
+   *
+   * Deliberately does not push. These numbers came from the server; echoing
+   * them back would republish a stale snapshot as if it were fresh.
+   *
+   * Ignored once a baseline exists, so a reconnect can't discard a fresher
+   * local one in favour of the server's older copy.
+   */
+  seedStatsBaseline(stats: ExportedStats[]): void {
+    if (this.statsBaseline || stats.length === 0) {
+      return;
+    }
+    this.statsBaseline = baselineFromDump(stats);
+  }
+
   async applyStatistics(statsMode: StatisticsMode): Promise<void> {
     await this.optimizer.setStatistics(statsMode);
     const stats = this.optimizer.ownMetadata;

--- a/src/remote/seed-stats-baseline.test.ts
+++ b/src/remote/seed-stats-baseline.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { ExportedStats } from "@query-doctor/core";
+import { Connectable } from "../sync/connectable.ts";
+import { ConnectionManager } from "../sync/connection-manager.ts";
+import { Remote } from "./remote.ts";
+import { detectDrift, type StatsBaseline } from "./stats-drift.ts";
+
+// Seeding only writes to memory, so no database is needed. Constructing Remote
+// opens no connection; the managers are only used once work is requested.
+function makeRemote(): Remote {
+  const target = Connectable.fromString(
+    "postgresql://postgres@localhost:5432/postgres",
+  );
+  return new Remote(target, ConnectionManager.forRemoteDatabase());
+}
+
+function table(name: string, reltuples: number): ExportedStats {
+  return {
+    schemaName: "public",
+    tableName: name,
+    reltuples,
+    relpages: 1,
+    relallvisible: 0,
+    columns: [],
+    indexes: [],
+  } as unknown as ExportedStats;
+}
+
+/**
+ * The baseline is private, so observe it the way the drift check does: seed,
+ * then ask whether a schema that has moved on is seen as drifted.
+ */
+function baselineOf(remote: Remote): StatsBaseline | undefined {
+  return (remote as unknown as { statsBaseline?: StatsBaseline }).statsBaseline;
+}
+
+describe("Remote.seedStatsBaseline", () => {
+  it("adopts the stored snapshot so the next poll can detect drift", () => {
+    const remote = makeRemote();
+
+    remote.seedStatsBaseline([table("users", 10_000)]);
+
+    const baseline = baselineOf(remote);
+    expect(baseline).toBeDefined();
+    // A table the stored snapshot never covered now reads as Shape Drift,
+    // which is the whole point of seeding.
+    const verdict = detectDrift(baseline!, {
+      reltuples: new Map([["public.users", 10_000], ["public.teams", 0]]),
+    });
+    expect(verdict.drifted).toBe(true);
+  });
+
+  it("leaves drift inert when the server holds no snapshot", () => {
+    const remote = makeRemote();
+
+    remote.seedStatsBaseline([]);
+
+    expect(baselineOf(remote)).toBeUndefined();
+  });
+
+  it("does not overwrite a baseline the analyzer already established", () => {
+    // A reconnect must not replace a fresh local baseline with the server's
+    // older copy, or every reconnect would re-dump.
+    const remote = makeRemote();
+    remote.seedStatsBaseline([table("users", 10_000)]);
+    const first = baselineOf(remote);
+
+    remote.seedStatsBaseline([table("users", 999), table("teams", 5)]);
+
+    expect(baselineOf(remote)).toBe(first);
+  });
+
+  it("does not push what it seeded", () => {
+    // Seeding adopts numbers that came from the server. Emitting them would
+    // republish a stale snapshot as if it were a fresh dump.
+    const remote = makeRemote();
+    let pushed = false;
+    remote.on("statsApplied", () => {
+      pushed = true;
+    });
+
+    remote.seedStatsBaseline([table("users", 10_000)]);
+
+    expect(pushed).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes Query-Doctor/Site#3670.

### Goal

Make a stale Production Statistics snapshot heal itself, with no user action.

#195 added drift detection, but it measures against the last dump *this process* pushed. An analyzer that has never pushed has no baseline and never drifts. That is every project whose snapshot was seeded by hand.

Query Doctor's own project is the case: an analyzer connected for 55 days, heartbeating, that has pushed statistics zero times. Its snapshot was taken by a manual psql dump on 2026-06-18 and six tables added since are uncovered.

### What

Before, drift armed only after this process dumped from source at least once.

After, the analyzer adopts the server's stored snapshot as its baseline on connect. The first schema poll then compares the live schema against it and re-dumps if it has fallen behind.

### How

`Remote.seedStatsBaseline` takes a snapshot and records it as the drift baseline. `ApiConnection.connectWithReconnect` calls `getProductionStats()` after connecting and passes the result in. That RPC already exists and is already called on the CI path, so there is no contract change.

Two guards, both tested:

- **Seeding never pushes.** These numbers came from the server. Emitting them would republish a stale snapshot as though it were a fresh dump.
- **Seeding is ignored once a baseline exists.** Otherwise a reconnect would discard a fresher local baseline for the server's older copy, and re-dump on every reconnect.

The fetch is fire-and-forget. If it fails, drift stays inert until a local dump sets a baseline, which is the behaviour before this change.

### Tests

`seed-stats-baseline.test.ts`, four cases: a seeded baseline makes a new table read as Shape Drift; an empty snapshot leaves drift inert; a second seed does not overwrite the first; seeding emits no `statsApplied`. No container needed, since seeding only writes to memory.