### PR TITLE
fix(remote): push the source dump instead of the optimizer's own metadata

### DIFF
--- a/src/remote/apply-statistics.test.ts
+++ b/src/remote/apply-statistics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { Statistics, type ExportedStats } from "@query-doctor/core";
+import { Connectable } from "../sync/connectable.ts";
+import { ConnectionManager } from "../sync/connection-manager.ts";
+import { Remote } from "./remote.ts";
+
+function makeRemote(): Remote {
+  return new Remote(
+    Connectable.fromString("postgresql://postgres@localhost:5432/postgres"),
+    ConnectionManager.forRemoteDatabase(),
+  );
+}
+
+function table(name: string, reltuples: number): ExportedStats {
+  return {
+    schemaName: "public",
+    tableName: name,
+    reltuples,
+    relpages: 1,
+    relallvisible: 0,
+    columns: [],
+    indexes: [],
+  } as unknown as ExportedStats;
+}
+
+/**
+ * `applyStatistics` decides what reaches the server's stored snapshot, so what
+ * it emits matters more than what it applies locally. The optimizer runs
+ * against a copy restored without table data, so its own metadata reports
+ * `reltuples = -1` everywhere — pushing that would replace a project's real
+ * production statistics with an empty snapshot.
+ */
+describe("Remote.applyStatistics", () => {
+  it("pushes the source dump, not the optimizer's own metadata", async () => {
+    const remote = makeRemote();
+    const sourceDump = [table("users", 5_000_000)];
+    // The optimizing database is empty; its dump is what must NOT be pushed.
+    vi.spyOn(remote.optimizer, "setStatistics").mockResolvedValue(undefined);
+    vi.spyOn(remote.optimizer, "restart").mockResolvedValue(undefined);
+    vi.spyOn(remote.optimizer, "ownMetadata", "get").mockReturnValue([
+      table("users", -1),
+    ]);
+    const pushed: ExportedStats[][] = [];
+    remote.on("statsApplied", (stats) => pushed.push(stats));
+
+    await remote.applyStatistics(Statistics.statsModeFromExport(sourceDump));
+
+    expect(pushed).toEqual([sourceDump]);
+    expect(pushed[0][0].reltuples).toBe(5_000_000);
+  });
+
+  it("pushes nothing for synthetic statistics", async () => {
+    // resetStats applies fromAssumption. Those numbers are invented, so
+    // publishing them as production statistics would be a lie.
+    const remote = makeRemote();
+    vi.spyOn(remote.optimizer, "setStatistics").mockResolvedValue(undefined);
+    vi.spyOn(remote.optimizer, "restart").mockResolvedValue(undefined);
+    vi.spyOn(remote.optimizer, "ownMetadata", "get").mockReturnValue([
+      table("users", -1),
+    ]);
+    let pushed = false;
+    remote.on("statsApplied", () => {
+      pushed = true;
+    });
+
+    await remote.applyStatistics(Statistics.defaultStatsMode);
+
+    expect(pushed).toBe(false);
+  });
+});

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -490,16 +490,18 @@ export class Remote extends EventEmitter<RemoteEvents> {
 
   async applyStatistics(statsMode: StatisticsMode): Promise<void> {
     await this.optimizer.setStatistics(statsMode);
-    const stats = this.optimizer.ownMetadata;
-    if (stats) {
-      // Record what we're about to push as the drift baseline. Only meaningful
-      // for source-derived stats; an imported snapshot describes someone else's
-      // database, so drifting against it would be nonsense.
-      if (statsMode.kind === "fromStatisticsExport") {
-        this.statsBaseline = baselineFromDump(stats);
-        this.lastStatsPushAt = Date.now();
-      }
-      this.emit("statsApplied", stats);
+    // Push the statistics we were handed, not `optimizer.ownMetadata`. That is
+    // a dump of the *optimizing* database, which is restored with
+    // `--exclude-table-data-and-children` and never durably analyzed, so every
+    // table in it reports `reltuples = -1` and every column `stats: null`.
+    // Sending it would overwrite the project's real snapshot with an empty one.
+    //
+    // `fromAssumption` carries no real numbers at all, so it pushes nothing —
+    // synthetic defaults are not this project's production statistics.
+    if (statsMode.kind === "fromStatisticsExport" && statsMode.stats.length > 0) {
+      this.statsBaseline = baselineFromDump(statsMode.stats);
+      this.lastStatsPushAt = Date.now();
+      this.emit("statsApplied", statsMode.stats);
     }
     // don't block the reply by awaiting all optimizations
     this.optimizer.restart();


### PR DESCRIPTION
### Goal

Stop a statistics push from replacing a project's production snapshot with an empty one. Found reviewing #197 after it merged.

### What

`applyStatistics` emitted `optimizer.ownMetadata`. That is a dump of the **optimizing** database, not the source:

- `QueryOptimizer` is constructed against `optimizingDbUDRL` (`remote.ts:113`), so `setStatistics` dumps from that connection (`query-optimizer.ts:156`) and passes the result as `plannerTables`.
- `Statistics.ownMetadata` is `plannerTables`. Core's own comment says `snapshot` carries the real numbers and passing the same array as both is "rarely what you want".
- The optimizing database is restored with `--exclude-table-data-and-children` (`schema-link.ts:124`), and `restoreStats` only ever runs inside a transaction that rolls back (`genalgo.ts:521`).

So the pushed payload reports `reltuples = -1` for every table and `stats: null` for every column. `relay.service.ts` stores it verbatim, overwriting the single project-level snapshot.

### Why it matters now

Nothing reached this path before. `applyStatistics` is only called from `updateStatistics` (declared in `ClientApi`, never invoked by the server), `resetStats`, and the HTTP import.

#197 seeds the drift baseline on connect, which is what first makes the drift path reachable in production. A drifted project would then push the empty dump, baseline itself against `reltuples = -1`, and on the next poll see every real table as Size Drift — because `Math.max(-1, 1)` gives a denominator of 1, so any table over the 1,000-row floor drifts. The result is a full `DUMP_STATS_SQL` against the customer's production database every 60 seconds, indefinitely.

Not yet live: the deployed analyzer predates #195 and #197. **Worth holding the analyzer deploy until this merges.**

### How

Push `statsMode.stats` — the dump we were handed — and baseline against the same array. Push nothing for `fromAssumption`, since synthetic defaults are not a project's production statistics; that also closes a smaller existing hole where `resetStats` pushed the empty dump for any mode, because the emit sat outside the mode check.

### Tests

`apply-statistics.test.ts` drives `applyStatistics` with a stubbed optimizer whose `ownMetadata` reports `reltuples = -1`, and asserts the emitted payload is the source dump with its real row count. A second case asserts `fromAssumption` emits nothing. Both fail against the previous behaviour.