### PR TITLE
feat: model CI queries at the repo's configured statistics scale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.17.0",
+        "@query-doctor/core": "^0.18.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-WN0so5G6dqmOx0v7NGw58nTbTlIXdX/eTHRIyxSP/uBLPGfYPmTna3B+o4s2KixA7uVez5uaCM//1KhJ36r/Ww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.18.0.tgz",
+      "integrity": "sha512-Z3ldmkUv92U2vxw9OI8J4eOn/MUxTMheqcRy+HJuCeMAcZGj2Sbv4XB60TzhtnLIbMt4EBCK/NysLeGxjlWm8w==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.17.0",
+    "@query-doctor/core": "^0.18.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, vi } from "vitest";
-import { DEFAULT_CONFIG } from "./config.ts";
+import { configuredStatisticsScale, DEFAULT_CONFIG } from "./config.ts";
 import type { ServerApi } from "@query-doctor/core";
 import type { RpcStub } from "capnweb";
 
@@ -54,4 +54,20 @@ test("passes repo and branch to getRepoConfig", async () => {
 
   await resolveConfig(api, "org/repo", "feat/my-branch");
   expect(getRepoConfig).toHaveBeenCalledWith("org/repo", "feat/my-branch");
+});
+
+test("reads the scale the repo is configured at", () => {
+  expect(configuredStatisticsScale({ ...DEFAULT_CONFIG, statisticsScale: 10 }))
+    .toBe(10);
+});
+
+test("falls back to the current data size when the repo config has no scale", () => {
+  // A Site that predates the setting, or a run with no repo config at all.
+  expect(configuredStatisticsScale(DEFAULT_CONFIG)).toBe(1);
+  expect(configuredStatisticsScale(undefined)).toBe(1);
+});
+
+test("ignores a scale the Site could not have meant", () => {
+  expect(configuredStatisticsScale({ statisticsScale: 0 })).toBe(1);
+  expect(configuredStatisticsScale({ statisticsScale: "10" })).toBe(1);
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,12 @@ export interface AnalyzerConfig {
    * it through `getRepoConfig`; the gate honours it the moment it arrives.
    */
   conditionPolicies?: RepoPolicyConfig;
+  /**
+   * The multiple of the current data the repo asks its queries to be planned
+   * against (#3119). 1 is the current size, which is what a repo gets until
+   * someone raises it in CI settings.
+   */
+  statisticsScale?: number;
 }
 
 export const DEFAULT_CONFIG: AnalyzerConfig = {
@@ -20,4 +26,21 @@ export const DEFAULT_CONFIG: AnalyzerConfig = {
   regressionThreshold: 0,
   ignoredQueryHashes: [],
   acknowledgedQueryHashes: [],
+  statisticsScale: 1,
 };
+
+/**
+ * The scale a repo is configured at, read off whatever the relay returned.
+ *
+ * The Site has sent `statisticsScale` on the repo config since #3115, but
+ * core's `RepoConfig` type does not declare it, so the read is defensive and
+ * lives in this one place. A missing, non-numeric, or sub-1 value means the
+ * current data size: an analyzer talking to an older Site keeps working, and a
+ * nonsense value never reaches the planner. Drop the cast once core ships the
+ * field on `RepoConfig`.
+ */
+export function configuredStatisticsScale(config: unknown): number {
+  const scale = (config as { statisticsScale?: unknown } | null | undefined)
+    ?.statisticsScale;
+  return typeof scale === "number" && scale >= 1 ? scale : 1;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { gateRegression } from "./gate/regression.ts";
 import { gateNewQuery } from "./gate/new-query.ts";
 import { gateSchemaChange } from "./gate/schema-change.ts";
 import { resolveVerdict } from "./gate/policy.ts";
-import { DEFAULT_CONFIG } from "./config.ts";
+import { configuredStatisticsScale, DEFAULT_CONFIG } from "./config.ts";
 import { ApiClient } from "./remote/api-client.ts";
 import { Remote } from "./remote/remote.ts";
 import { ConnectionManager } from "./sync/connection-manager.ts";
@@ -99,6 +99,14 @@ async function runInCI(
       ? new PgbadgerSource(logPath)
       : remoteDbManager.getConnectorFor(sourcePostgresUrl);
 
+    const statisticsScale = configuredStatisticsScale(config);
+    if (statisticsScale !== 1) {
+      log.info(
+        `Modeling queries at ${statisticsScale}x the current data size`,
+        "main",
+      );
+    }
+
     const runner = await Runner.build({
       targetPostgresUrl,
       sourcePostgresUrl,
@@ -107,6 +115,7 @@ async function runInCI(
       ignoredQueryHashes: config.ignoredQueryHashes,
       remote,
       productionStats: productionStats ?? undefined,
+      statisticsScale,
     });
     let allResults: QueryProcessResult[];
     let reportContext;

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -80,3 +80,53 @@ describe("Runner.determineStatsMode precedence", () => {
     expect(await Runner.determineStatsMode()).toEqual(syntheticMode);
   });
 });
+
+describe("Runner.determineStatsMode at a configured scale", () => {
+  const TABLE: ExportedStats = {
+    tableName: "users",
+    schemaName: "public",
+    relpages: 10,
+    reltuples: 166_000,
+    relallvisible: 8,
+    columns: [],
+    indexes: [],
+  };
+
+  /** CI always resolves a static mode; this narrows the union to read it. */
+  async function staticMode(
+    productionStats?: ExportedStats[],
+    scale?: number,
+  ) {
+    const strategy = await Runner.determineStatsMode(
+      undefined,
+      productionStats,
+      scale,
+    );
+    if (strategy.type !== "static") {
+      throw new Error(`expected a static stats mode, got ${strategy.type}`);
+    }
+    return strategy.stats;
+  }
+
+  test("models production stats at the repo's scale", async () => {
+    const stats = await staticMode([TABLE], 10);
+
+    expect(stats.kind).toBe("fromStatisticsExport");
+    expect(stats.scale).toBe(10);
+  });
+
+  test("models the synthetic assumption at the repo's scale", async () => {
+    const stats = await staticMode(undefined, 1000);
+
+    expect(stats.kind).toBe("fromAssumption");
+    expect(stats.scale).toBe(1000);
+  });
+
+  test("leaves the mode unscaled when the repo is configured at 1x", async () => {
+    expect((await staticMode([TABLE], 1)).scale).toBeUndefined();
+  });
+
+  test("leaves the mode unscaled when no scale is configured", async () => {
+    expect((await staticMode([TABLE])).scale).toBeUndefined();
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -14,7 +14,7 @@ import { Connectable } from "./sync/connectable.ts";
 import { Remote, StatisticsStrategy } from "./remote/remote.ts";
 import { ConnectionManager } from "./sync/connection-manager.ts";
 import type { OptimizedQuery } from "./sql/recent-query.ts";
-import { ExportedStats, Statistics } from "@query-doctor/core";
+import { ExportedStats, Statistics, type StatisticsMode } from "@query-doctor/core";
 import { readFile } from "node:fs/promises";
 import { buildQueries } from "./reporters/site-api.ts";
 
@@ -37,6 +37,10 @@ export class Runner {
     // Real production statistics pulled from the Site API. When present, queries
     // are costed against true prod cardinality instead of synthetic assumptions.
     productionStats?: ExportedStats[];
+    // The repo's configured statistics scale. Queries are then planned against
+    // this multiple of the data, which answers whether they hold up at a size
+    // the database hasn't reached yet.
+    statisticsScale?: number;
   }) {
     const remote = options.remote ?? new Remote(
       options.targetPostgresUrl,
@@ -45,7 +49,7 @@ export class Runner {
       { disableQueryLoader: true }
     );
     await remote.syncFrom(options.sourcePostgresUrl,
-      await Runner.determineStatsMode(options.statisticsPath, options.productionStats)
+      await Runner.determineStatsMode(options.statisticsPath, options.productionStats, options.statisticsScale)
     );
     await remote.optimizer.finish;
     return new Runner(
@@ -59,14 +63,23 @@ export class Runner {
   // Stats-mode precedence for CI: real production stats pulled from the Site API
   // win, then an explicit stats file, then synthetic assumptions. CI never dumps
   // stats from the ephemeral target database itself.
+  //
+  // `scale` applies to whichever mode wins: core multiplies the planner's view
+  // of table and index size by it and leaves column statistics alone. A scale of
+  // 1 is left off the mode entirely, so a repo at the default size posts exactly
+  // the payload it did before.
   static async determineStatsMode(
     statsPath?: string,
     productionStats?: ExportedStats[],
+    scale?: number,
   ): Promise<StatisticsStrategy> {
+    const atScale = <T extends StatisticsMode>(stats: T): T =>
+      scale && scale !== 1 ? { ...stats, scale } : stats;
+
     if (productionStats && productionStats.length > 0) {
       return {
         type: "static",
-        stats: Statistics.statsModeFromExport(productionStats),
+        stats: atScale(Statistics.statsModeFromExport(productionStats)),
       };
     }
     if (statsPath) {
@@ -75,20 +88,20 @@ export class Runner {
       const stats = ExportedStats.array().parse(rawStats);
       return {
         type: "static",
-        stats: {
+        stats: atScale({
           kind: "fromStatisticsExport",
           source: { kind: "path", path: statsPath },
           stats
-        }
+        })
       }
     }
 
     return {
       type: "static",
-      stats: {
+      stats: atScale({
         kind: "fromAssumption",
         reltuples: 10_000_000,
-      }
+      })
     }
   }
 


### PR DESCRIPTION
Implements Query-Doctor/Site#3119, the last child of the predict-at-scale epic (Query-Doctor/Site#3114). The Site side is on `feat-predict-at-scale` (Query-Doctor/Site#3698).

### Goal

Query Doctor's homepage promises performance predicted at 10× and 1000× the data. Everything for that now exists except the step that reads the setting: the Site stores a per-repo statistics scale, the app labels a run with it, the API refuses to compare runs across a scale change, and core multiplies row counts by it. This PR is the analyzer reading the setting and using it.

### What

Before: a repo could set a statistics scale in CI settings and nothing happened. Every run was planned against the current data.

After: a repo set to 10× has its CI queries planned against ten times the table and index sizes, so an index that only starts mattering at that size shows up before the table gets there. The run log says `Modeling queries at 10x the current data size`. A repo left at 1× posts exactly the payload it posted before.

### How

Read `src/config.ts` first. `configuredStatisticsScale` is the one place that reads the setting off the relay's repo config. The read is defensive because core's `RepoConfig` type does not declare `statisticsScale` even though the Site has sent it since Site#3115: a missing, non-numeric, or sub-1 value means the current size, so an analyzer talking to an older Site keeps working and a nonsense value never reaches the planner. The cast can go once core ships the field.

`Runner.determineStatsMode` takes the scale and applies it to whichever mode wins its existing precedence: production stats, then a stats file, then the synthetic assumption. It is applied in one place, `atScale`, rather than three times inside the branches. A scale of 1 is left off the mode entirely, which keeps the posted payload byte-identical for repos that never touch the setting.

Nothing else changes shape. The scale rides inside the `statisticsMode` the reporter already posts, and the Site stamps it on the run (Site#3694). `CiQueryOptimization.cost` stays a single number.

`@query-doctor/core` moves to `^0.18.0`, the first published version whose `StatisticsMode` carries `scale`.

### Tests

`src/config.test.ts`: the scale is read from a repo config, a config without one means 1×, and a `0` or a `"10"` is ignored.

`src/runner.test.ts`: production stats are modeled at the configured scale, so is the synthetic assumption, and 1× or no scale leaves the mode unscaled. Written before the change; the first two failed with `expected undefined to be 10`.

`npm run test`: 374 passed across 38 files. `npm run typecheck`: clean.

### Verifying end to end

Not done here, and worth doing on a real repo once the Site branch merges: set a repo to 10×, push, and check the run header reads `modeled at 10×` and the costs move. The Site side refuses to compare that first run against its 1× baseline, which is the intended re-baseline (Site#3118).