### PR TITLE
feat(comment): name a query by its call site

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import n from "nunjucks";
-import { formatCost, queryPreview, buildViewModel } from "./github.ts";
+import { formatCost, queryPreview, buildViewModel, callSite } from "./github.ts";
 import { isQueryLong, renderExplain, type ReportContext } from "../reporter.ts";
 import type { CiRunMetadata, RunComparison } from "../site-api.ts";
 
@@ -301,6 +301,7 @@ describe("buildViewModel", () => {
             hash: "regressed-1",
             query: "SELECT 1",
             formattedQuery: "SELECT 1",
+            tags: [],
             previousCost: 100,
             currentCost: 500,
             regressionPercentage: 400,
@@ -322,6 +323,7 @@ describe("buildViewModel", () => {
             hash: "improved-1",
             query: "SELECT 1",
             formattedQuery: "SELECT 1",
+            tags: [],
             previousCost: 500,
             currentCost: 100,
             improvementPercentage: 80,
@@ -345,6 +347,7 @@ describe("buildViewModel", () => {
             hash: "improved-1",
             query: "SELECT 1",
             formattedQuery: "SELECT 1",
+            tags: [],
             previousCost: 500,
             currentCost: 100,
             improvementPercentage: 80,
@@ -533,6 +536,7 @@ describe("CI-signal metadata parity (analyzer#141)", () => {
         hash: "regressed-1",
         query: "SELECT 1",
         formattedQuery: "SELECT 1",
+        tags: [],
         previousCost: 120,
         currentCost: 170,
         regressionPercentage: 42,
@@ -543,6 +547,7 @@ describe("CI-signal metadata parity (analyzer#141)", () => {
         hash: "improved-1",
         query: "SELECT 2",
         formattedQuery: "SELECT 2",
+        tags: [],
         previousCost: 500,
         currentCost: 100,
         improvementPercentage: 80,
@@ -1023,5 +1028,29 @@ describe("heading wording", () => {
     });
 
     expect(renderTemplate(ctx)).toContain("### 1 failing and 1 successful check");
+  });
+});
+
+describe("callSite", () => {
+  test("names a query by its function and file", () => {
+    expect(
+      callSite([
+        { key: "func_name", value: "CiRepository.findLatest" },
+        { key: "file", value: "/home/runner/work/Site/Site/apps/api/src/ci/ci.repository.ts:210:8" },
+      ]),
+    ).toEqual({
+      name: "CiRepository.findLatest",
+      file: "apps/api/src/ci/ci.repository.ts:210:8",
+    });
+  });
+
+  test("falls back to the file when the function is missing", () => {
+    expect(
+      callSite([{ key: "file", value: "apps/api/src/ci/ci.repository.ts:12:3" }]),
+    ).toEqual({ name: "apps/api/src/ci/ci.repository.ts:12:3", file: undefined });
+  });
+
+  test("returns nothing when the run carries no tags", () => {
+    expect(callSite([])).toBeUndefined();
   });
 });

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -35,22 +35,26 @@ n.configure({ autoescape: false, trimBlocks: true, lstripBlocks: true });
 
 interface DisplayRecommendation extends ReportIndexRecommendation {
   queryPreview: string;
+  site?: { name: string; file: string | undefined };
   /** Below the `minimumCost` floor: shown for context, but does not gate the PR. */
   belowThreshold: boolean;
 }
 
 interface DisplayRegression extends RegressedQuery {
   queryPreview: string;
+  site?: { name: string; file: string | undefined };
 }
 
 interface DisplayImprovement extends ImprovedQuery {
   queryPreview: string;
+  site?: { name: string; file: string | undefined };
   indexesChanged: boolean;
 }
 
 interface DisplayNewQuery {
   hash: string;
   queryPreview: string;
+  site?: { name: string; file: string | undefined };
   /** Pre-rendered "cost N" label, or "" when the query has no extractable cost. */
   costLabel: string;
 }
@@ -88,6 +92,7 @@ function addPreviews(
   return recs.map((r) => ({
     ...r,
     queryPreview: queryPreview(r.formattedQuery),
+    site: callSite((r as { tags?: { key: string; value: string }[] }).tags),
     belowThreshold,
   }));
 }
@@ -180,6 +185,26 @@ function buildModeledTablesNotice(
     count: tables.length,
     list: rest > 0 ? `${names}, and ${rest} more` : names,
   };
+}
+
+
+/**
+ * Name a query by where it is written, from its SQLCommenter tags. The stored
+ * preview truncates at the column list, so a hash is otherwise the only handle a
+ * reader gets. `file` arrives absolute from the CI runner, so it is trimmed to a
+ * repo-relative path. Returns undefined when the run carries no tags at all.
+ */
+export function callSite(
+  tags: { key: string; value: string }[] | undefined,
+): { name: string; file: string | undefined } | undefined {
+  const get = (key: string) => tags?.find((t) => t.key === key)?.value;
+  const funcName = get("func_name");
+  const raw = get("file");
+  const file = raw?.includes("/Site/")
+    ? raw.slice(raw.lastIndexOf("/Site/") + "/Site/".length)
+    : raw;
+  if (!funcName && !file) return undefined;
+  return funcName ? { name: funcName, file } : { name: file!, file: undefined };
 }
 
 export function buildViewModel(ctx: ReportContext) {

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -6,9 +6,9 @@
 {% if g.condition == "new-query-index" and g.fired %}
 {% for r in displayRecommendations %}
 {% set link = queryLinks[r.fingerprint] %}
-{% if link %}[<code>{{ r.queryPreview }}</code>]({{ link }}){% else %}<code>{{ r.queryPreview }}</code>{% endif %}
+{% if r.site %}{% if link %}[`{{ r.site.name }}`]({{ link }}){% else %}`{{ r.site.name }}`{% endif %}{% else %}{% if link %}[<code>{{ r.queryPreview }}</code>]({{ link }}){% else %}<code>{{ r.queryPreview }}</code>{% endif %}{% endif %}
 
-<sub>plans at {{ formatCost(r.baseCost) }}, or <b>{{ formatCost(r.optimizedCost) }}</b> with {{ "this index" if r.proposedIndexes.length == 1 else "these indexes" }} ({{ (((r.baseCost - r.optimizedCost) / r.baseCost) * 100) | round(0) }}% improvement)</sub>
+<sub>{% if r.site and r.site.file %}{{ r.site.file }} · {% endif %}plans at {{ formatCost(r.baseCost) }}, or <b>{{ formatCost(r.optimizedCost) }}</b> with {{ "this index" if r.proposedIndexes.length == 1 else "these indexes" }} ({{ (((r.baseCost - r.optimizedCost) / r.baseCost) * 100) | round(0) }}% improvement)</sub>
 
 ```sql
 {% for idx in r.proposedIndexes %}CREATE INDEX ON {{ idx }};

--- a/src/reporters/site-api.test.ts
+++ b/src/reporters/site-api.test.ts
@@ -753,3 +753,41 @@ describe("fetchPreviousRun retry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
+
+describe("compareRuns carries the call site (ADR-0009)", () => {
+  const withTags = (hash: string, cost: number, funcName: string) => ({
+    ...makeQuery(hash, cost),
+    tags: [
+      { key: "func_name", value: funcName },
+      { key: "file", value: "apps/api/src/ci/ci.repository.ts:210:8" },
+    ],
+  });
+
+  test("a regressed query keeps the tags that name it", async () => {
+    const previousRun = makePreviousRun([withTags("hash-a", 100, "CiRepository.findLatest")]);
+    const result = await compareRuns(
+      [withTags("hash-a", 200, "CiRepository.findLatest")],
+      previousRun,
+      10,
+    );
+
+    expect(result.regressed[0]?.tags).toContainEqual({
+      key: "func_name",
+      value: "CiRepository.findLatest",
+    });
+  });
+
+  test("an improved query keeps them too", async () => {
+    const previousRun = makePreviousRun([withTags("hash-b", 200, "CiRepository.findAll")]);
+    const result = await compareRuns(
+      [withTags("hash-b", 100, "CiRepository.findAll")],
+      previousRun,
+      10,
+    );
+
+    expect(result.improved[0]?.tags).toContainEqual({
+      key: "func_name",
+      value: "CiRepository.findAll",
+    });
+  });
+});

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -223,6 +223,8 @@ export interface RegressedQuery {
   hash: string;
   query: string;
   formattedQuery: string;
+  /** SQLCommenter tags from the current run: `func_name`, `file`, `db_driver`. */
+  tags: SQLCommenterTag[];
   previousCost: number;
   currentCost: number;
   regressionPercentage: number;
@@ -232,6 +234,8 @@ export interface ImprovedQuery {
   hash: string;
   query: string;
   formattedQuery: string;
+  /** SQLCommenter tags from the current run: `func_name`, `file`, `db_driver`. */
+  tags: SQLCommenterTag[];
   previousCost: number;
   currentCost: number;
   improvementPercentage: number;
@@ -414,6 +418,7 @@ export async function compareRuns(
         hash: current.hash,
         query: current.query,
         formattedQuery: current.formattedQuery,
+        tags: current.tags,
         previousCost: prevCost,
         currentCost,
         regressionPercentage: changePct,
@@ -432,6 +437,7 @@ export async function compareRuns(
         hash: current.hash,
         query: current.query,
         formattedQuery: current.formattedQuery,
+        tags: current.tags,
         previousCost: prevCost,
         currentCost,
         improvementPercentage: Math.abs(changePct),


### PR DESCRIPTION
## Goal

A comment row should tell you which code to open. Follow-up to #201, which built the gates-first layout but could only identify a query by hash.

## What

Before: `9e545998 plans at 1,230, or 346 with these indexes`

After: `CiRepository.findLatest`, with `apps/api/src/ci/ci.repository.ts:210:8` underneath.

Every query in a run already carries SQLCommenter tags: `func_name`, `file`, `db_driver`. `GET /ci/runs/:id` returns them for all 101 queries on a recent run. `compareRuns` narrowed each query to a shape that dropped them, so the surface where naming matters most was the one surface without a name.

## How

Read `compareRuns` in `src/reporters/site-api.ts` first: `RegressedQuery` and `ImprovedQuery` gain `tags`, copied from the current run's payload. `newQueries` already kept the full payload, so it needed nothing.

`callSite` in `github.ts` turns those tags into a name and a file. The `file` tag arrives absolute from the runner (`/home/runner/work/Site/Site/apps/...`), so it is trimmed to a repo-relative path. A query with no `func_name` falls back to its file, and one with no tags falls back to the SQL preview, which is what the comment showed before.

Two limits worth knowing. `func_name` is not unique: `CiRepository.findAll` covered 8 hashes on the run I checked, so two rows can share a label and differ; the link disambiguates. About 8 of 101 queries carry no `func_name` at all.

## Tests

`site-api.test.ts` covers a regressed and an improved query keeping their tags. `github.test.ts` covers `callSite` naming a query, falling back to the file, and returning nothing when a run carries no tags. Full suite: 385 passing, 39 files, typecheck clean.