### PR TITLE
fix(github): stop the gate glyphs rendering as links

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -1054,3 +1054,17 @@ describe("callSite", () => {
     expect(callSite([])).toBeUndefined();
   });
 });
+
+describe("gate icons", () => {
+  test("wraps each glyph so GitHub does not turn it into a link", () => {
+    const ctx = makeContext({
+      gates: [
+        { condition: "schema-drift", label: "Schema drift", fired: false, conclusion: "success", found: "No schema changes" },
+      ],
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("<picture><img src=");
+    expect(output).toContain("</picture>");
+  });
+});

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -2,7 +2,7 @@
 ### {% if gateSummary.failing > 0 %}{{ gateSummary.failing }} failing and {% endif %}{{ gateSummary.successful }} successful check{{ "" if gateSummary.successful == 1 else "s" }}
 
 {% for g in gates %}
-<img src="{{ gateIconBase }}/{{ "fail" if g.conclusion == "failure" else ("warn" if g.conclusion == "neutral" else "pass") }}.svg" width="14" height="16" align="absmiddle" alt=""> &nbsp;**{{ g.label }}** — {{ g.found }}
+<picture><img src="{{ gateIconBase }}/{{ "fail" if g.conclusion == "failure" else ("warn" if g.conclusion == "neutral" else "pass") }}.svg" width="14" height="16" align="absmiddle" alt=""></picture> &nbsp;**{{ g.label }}** — {{ g.found }}
 {% if g.condition == "new-query-index" and g.fired %}
 {% for r in displayRecommendations %}
 {% set link = queryLinks[r.fingerprint] %}


### PR DESCRIPTION
## Goal

The status glyph on each gate line was clickable and navigated away from the pull request. Follow-up to #201.

## What

Before: clicking a gate's icon opened the raw SVG.

After: the icon is not a link.

## How

GitHub's markdown pipeline wraps every `<img>` in an anchor to its Camo URL. I probed the four ways out against `POST /markdown`: a bare `<img>` gets wrapped, an `<a>` with no `href` gets replaced by GitHub's own anchor, an `<a href="#">` survives but still jumps the page, and `<picture>` is left alone entirely.

So the fix is one wrapper in `success.md.j2`. As a side effect the `raw.githubusercontent.com` URL is no longer Camo-proxied, since GitHub serves its own domain directly.

## Tests

`github.test.ts` asserts the glyph renders inside `<picture>`. Full suite: 381 passing, 39 files, typecheck clean.