### PR TITLE
fix(github): expand the cost-regression gate

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -1055,6 +1055,41 @@ describe("callSite", () => {
   });
 });
 
+describe("cost regression detail", () => {
+  test("a fired regression gate lists the queries that got more expensive", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        regressed: [
+          { hash: "h1", query: "q", formattedQuery: "SELECT 1", tags: [],
+            previousCost: 1211, currentCost: 1289, regressionPercentage: 6.4 },
+        ],
+      }),
+      gates: [
+        { condition: "regression-beyond-threshold", label: "Cost regression", fired: true, conclusion: "failure", found: "1 query got more expensive" },
+      ],
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("1,211");
+    expect(output).toContain("1,289");
+  });
+});
+
+describe("regression rows carry the call site", () => {
+  test("names the function instead of the SQL preview", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        regressed: [{ hash: "h1", query: "q", formattedQuery: "SELECT 1",
+          tags: [{ key: "func_name", value: "DashboardRepository.findFunnelCounts" }],
+          previousCost: 20965, currentCost: 37205, regressionPercentage: 77 }],
+      }),
+      gates: [{ condition: "regression-beyond-threshold", label: "Cost regression", fired: true, conclusion: "failure", found: "1 query got more expensive" }],
+    });
+
+    expect(renderTemplate(ctx)).toContain("DashboardRepository.findFunnelCounts");
+  });
+});
+
 describe("gate icons", () => {
   test("wraps each glyph so GitHub does not turn it into a link", () => {
     const ctx = makeContext({

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -103,6 +103,7 @@ function addRegressionPreviews(
   return regressions.map((r) => ({
     ...r,
     queryPreview: queryPreview(r.formattedQuery),
+    site: callSite(r.tags),
   }));
 }
 

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -15,6 +15,15 @@
 {% endfor %}```
 {% endfor %}
 {% endif %}
+{% if g.condition == "regression-beyond-threshold" and g.fired %}
+{% for q in displayRegressed %}
+{% set link = queryLinks[q.hash] %}
+{% if q.site %}{% if link %}[`{{ q.site.name }}`]({{ link }}){% else %}`{{ q.site.name }}`{% endif %}{% else %}{% if link %}[<code>{{ q.queryPreview }}</code>]({{ link }}){% else %}<code>{{ q.queryPreview }}</code>{% endif %}{% endif %}
+
+<sub>{% if q.site and q.site.file %}{{ q.site.file }} · {% endif %}{{ formatCost(q.previousCost) }} on the baseline, {{ formatCost(q.currentCost) }} here (+{{ q.regressionPercentage | round(0) }}%)</sub>
+
+{% endfor %}
+{% endif %}
 {% if g.condition == "schema-drift" and g.fired and schemaChange.hasChanges %}
 {% for group in schemaChange.groups %}
 **{{ schemaChangeHeading(group.kind) }}**


### PR DESCRIPTION
## Goal

A gate that blocks the check should show what it blocked on. Follow-up to #201.

## What

Before. The first live run of the new comment blocked on 9 regressions and listed none of them:

```
x Cost regression — 9 queries got more expensive
  Untested data access — No changed data-access file without a test
  New query — No new queries
```

After. Each regressed query gets a row with its call site, both costs, and the percentage:

```
x Cost regression — 9 queries got more expensive
      ProjectQueriesRepository.findByProject
      apps/api/src/projects/project-queries.repository.ts:269:8 · 397,498 on the baseline, 718,215 here (+81%)

      DashboardRepository.findFunnelCounts
      apps/api/src/dashboard/dashboard.repository.ts:143:8 · 20,965 on the baseline, 37,205 here (+77%)

  Untested data access — No changed data-access file without a test
```

Those figures are the real ones from run `019fb8fd`, not illustrations.

## How

Two changes.

`success.md.j2` gains a `regression-beyond-threshold` block, matching the shape the other two gates already use. It reads `displayRegressed`, which the view model has always built.

`addRegressionPreviews` in `github.ts` now attaches `site`. #202 added the call site to the recommendation previews and missed this builder, so regression rows would have rendered `SELECT …` instead of the function name. Rendering the template is what surfaced it; no test covered it.

## Tests

`github.test.ts` asserts a fired regression gate renders both costs, and that a row names the function rather than the SQL preview. Full suite: 387 passing, 39 files, typecheck clean.

## Not in this PR

The gate line says "9 queries got more expensive" without naming the rule. It is 9 because 25 queries rose, 13 rose past this repo's 10% threshold, and 9 of those are also above the 100 cost floor. The run page reports 25, so the two surfaces disagree without either being wrong. Naming the threshold in the copy is a separate change.