### PR TITLE
feat(github): name the rule on the cost-regression line

### DIFF
--- a/src/gate/evaluate.test.ts
+++ b/src/gate/evaluate.test.ts
@@ -132,3 +132,25 @@ describe("gate copy", () => {
     expect(found("new-query")).toBe("1 new query, with no prior baseline");
   });
 });
+
+describe("gate copy names the rule", () => {
+  it("states the threshold and the cost floor a regression had to clear", () => {
+    const gates = evaluateGates({
+      regressedCount: 9,
+      regressionThreshold: 10,
+      minimumCost: 100,
+    });
+
+    expect(
+      gates.find((g) => g.condition === "regression-beyond-threshold")?.found,
+    ).toBe("9 queries went up more than 10%, where either cost is at least 100");
+  });
+
+  it("names the threshold when nothing crossed it", () => {
+    const gates = evaluateGates({ regressionThreshold: 10, minimumCost: 100 });
+
+    expect(
+      gates.find((g) => g.condition === "regression-beyond-threshold")?.found,
+    ).toBe("No query went up more than 10%");
+  });
+});

--- a/src/gate/evaluate.ts
+++ b/src/gate/evaluate.ts
@@ -60,6 +60,10 @@ export interface GateFacts {
   untestedDataAccessFileCount?: number;
   /** Queries carrying a high-value rewrite or index nudge. */
   highValueNudgeCount?: number;
+  /** The repo's regression threshold, as a percentage. Named in the gate's line. */
+  regressionThreshold?: number;
+  /** The repo's cost floor. A regression under it on both sides is ignored. */
+  minimumCost?: number;
 }
 
 
@@ -74,10 +78,19 @@ function describe(condition: GateCondition, facts: GateFacts): string {
   const nudges = facts.highValueNudgeCount ?? 0;
 
   switch (condition) {
-    case "regression-beyond-threshold":
+    case "regression-beyond-threshold": {
+      // Name the rule, not just the count: the run page reports every increase,
+      // so a bare number here reads as a contradiction of it.
+      const pct = facts.regressionThreshold;
+      const bar = pct === undefined ? "" : ` more than ${pct}%`;
+      const floor =
+        facts.minimumCost && facts.minimumCost > 0
+          ? `, where either cost is at least ${facts.minimumCost}`
+          : "";
       return regressed > 0
-        ? `${regressed} ${plural(regressed, "query", "queries")} got more expensive`
-        : "No query got more expensive than the threshold allows";
+        ? `${regressed} ${plural(regressed, "query went up", "queries went up")}${bar}${floor}`
+        : `No query went up${bar}`;
+    }
     case "untested-data-access":
       return untested > 0
         ? `${untested} changed data-access ${plural(untested, "file ships", "files ship")} with no related test`

--- a/src/main.ts
+++ b/src/main.ts
@@ -283,6 +283,8 @@ async function runInCI(
             reportContext.runMetadata?.schemaChange?.changed === true,
           untestedDataAccessFileCount:
             reportContext.testPresenceVerdict?.dataAccessFiles.length ?? 0,
+          regressionThreshold: config.regressionThreshold,
+          minimumCost: config.minimumCost,
         },
         policyConfig,
       );


### PR DESCRIPTION
## Goal

A gate line should say what the gate checked, not only what it counted. Follow-up to #201.

## What

On run `019fb8fd` the comment said `Cost regression — 9 queries got more expensive` and the run detail page said `25 regressed`. Both are correct and they look like a contradiction.

Reproduced from the two run payloads:

```
25  queries increased at all                          <- what the run page reports
13  increased past the 10% threshold
 9  ...and are not both sides under the 100 cost floor <- what the gate blocks on
```

After: `Cost regression — 9 queries went up more than 10%, where either cost is at least 100`

## How

`GateFacts` gains `regressionThreshold` and `minimumCost`, threaded from the repo config in `main.ts`. The copy in `evaluate.ts` reads them, so a repo that sets 20% and a floor of 500 gets its own numbers rather than a hardcoded sentence.

The floor is worded to match `compareRuns`, which skips a regression only when *both* the previous and current cost sit under it. A query going 50 to 300 is counted, so "under a cost of 100 is ignored" would have described a simpler rule than the code applies.

## Tests

`evaluate.test.ts` covers the fired line naming both numbers, and the passing line naming the threshold. Full suite: 390 passing, 39 files, typecheck clean.