### PR TITLE
feat(github): say which table grew when queries got more expensive

### DIFF
--- a/src/gate/table-growth.test.ts
+++ b/src/gate/table-growth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { tableGrowth } from "./table-growth.ts";
+
+const stats = (rows: [string, number][]) => ({
+  reltuples: rows.map(([relname, reltuples]) => ({
+    relname, reltuples, schema_name: "public", relpages: 1, relallvisible: 1,
+  })),
+});
+
+describe("tableGrowth", () => {
+  it("names the table that grew most between the baseline and this run", () => {
+    const grown = tableGrowth(
+      stats([["project_queries", 3503], ["users", 121]]),
+      stats([["project_queries", 6290], ["users", 125]]),
+    );
+
+    expect(grown[0]).toEqual({
+      table: "project_queries",
+      before: 3503,
+      after: 6290,
+      percent: 80,
+    });
+  });
+
+  it("ignores a table that barely moved", () => {
+    const grown = tableGrowth(
+      stats([["users", 121]]),
+      stats([["users", 125]]),
+    );
+
+    expect(grown).toEqual([]);
+  });
+
+  it("returns nothing when either side has no statistics", () => {
+    expect(tableGrowth(undefined, stats([["users", 1]]))).toEqual([]);
+  });
+});

--- a/src/gate/table-growth.ts
+++ b/src/gate/table-growth.ts
@@ -1,0 +1,58 @@
+// Why a query got more expensive when the diff did not touch it.
+//
+// A cost comparison sees two numbers and calls the difference a regression. But
+// a plan's cost moves when the data underneath it moves, and the baseline can be
+// a day old — long enough for a table to grow by most of its size. On the run
+// that prompted this, `project_queries` grew 80% overnight and nine queries
+// reading it "regressed" on a pull request that changed one markdown file.
+//
+// Both runs carry the row counts the planner used, so the comment can say which
+// table grew instead of leaving the reader to blame their own diff.
+
+/** The row-count snapshot a run was planned against (`computedStats`). */
+export interface RunStats {
+  reltuples: { relname: string; schema_name: string; reltuples: number }[];
+}
+
+export interface TableGrowth {
+  table: string;
+  before: number;
+  after: number;
+  /** Growth as a percentage of the baseline, rounded. */
+  percent: number;
+}
+
+/** Growth below this is noise, not an explanation for a cost move. */
+const MIN_GROWTH_PERCENT = 10;
+
+/**
+ * Tables that grew between the baseline run and this one, largest first. Empty
+ * when either run has no statistics, which is the case for a run planned on
+ * assumptions rather than an export.
+ */
+export function tableGrowth(
+  baseline: RunStats | undefined,
+  current: RunStats | undefined,
+): TableGrowth[] {
+  if (!baseline?.reltuples || !current?.reltuples) return [];
+
+  const before = new Map(
+    baseline.reltuples
+      .filter((r) => r.schema_name === "public")
+      .map((r) => [r.relname, r.reltuples]),
+  );
+
+  const grown: TableGrowth[] = [];
+  for (const row of current.reltuples) {
+    if (row.schema_name !== "public") continue;
+    const was = before.get(row.relname);
+    // A table absent from the baseline has no growth to report, and one that
+    // was empty would divide by zero.
+    if (was === undefined || was <= 0 || row.reltuples <= was) continue;
+    const percent = Math.round(((row.reltuples - was) / was) * 100);
+    if (percent < MIN_GROWTH_PERCENT) continue;
+    grown.push({ table: row.relname, before: was, after: row.reltuples, percent });
+  }
+
+  return grown.sort((a, b) => b.percent - a.percent);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { evaluateTestPresence } from "./gate/test-presence.ts";
 import { gateRegression } from "./gate/regression.ts";
 import { gateNewQuery } from "./gate/new-query.ts";
 import { evaluateGates } from "./gate/evaluate.ts";
+import { tableGrowth } from "./gate/table-growth.ts";
 import { gateSchemaChange } from "./gate/schema-change.ts";
 import { resolveVerdict } from "./gate/policy.ts";
 import { DEFAULT_CONFIG } from "./config.ts";
@@ -274,6 +275,10 @@ async function runInCI(
             config.minimumCost,
           )
         : [];
+      reportContext.tableGrowth = tableGrowth(
+        previousRun?.computedStats,
+        reportContext.computedStats,
+      );
       reportContext.gates = evaluateGates(
         {
           regressedCount: reportContext.comparison?.regressed.length ?? 0,

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -1103,3 +1103,30 @@ describe("gate icons", () => {
     expect(output).toContain("</picture>");
   });
 });
+
+describe("table growth explains a regression", () => {
+  test("names the table that grew under a fired regression gate", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        regressed: [{ hash: "h1", query: "q", formattedQuery: "SELECT 1", tags: [],
+          previousCost: 20965, currentCost: 37205, regressionPercentage: 77 }],
+      }),
+      gates: [{ condition: "regression-beyond-threshold", label: "Cost regression", fired: true, conclusion: "failure", found: "1 query went up more than 10%" }],
+      tableGrowth: [{ table: "project_queries", before: 3503, after: 6290, percent: 80 }],
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("project_queries");
+    expect(output).toContain("80%");
+  });
+
+  test("says nothing when no table grew", () => {
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      gates: [{ condition: "regression-beyond-threshold", label: "Cost regression", fired: true, conclusion: "failure", found: "1 query went up more than 10%" }],
+      tableGrowth: [],
+    });
+
+    expect(renderTemplate(ctx)).not.toContain("grew");
+  });
+});

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -16,6 +16,10 @@
 {% endfor %}
 {% endif %}
 {% if g.condition == "regression-beyond-threshold" and g.fired %}
+{% if tableGrowth and tableGrowth.length > 0 %}
+<sub>Bigger tables since the baseline: {% for gr in tableGrowth %}<code>{{ gr.table }}</code> +{{ gr.percent }}% ({{ formatCost(gr.before) }} → {{ formatCost(gr.after) }} rows){% if not loop.last %}, {% endif %}{% endfor %}. A plan costs more against more rows, whatever the diff changed.</sub>
+
+{% endif %}
 {% for q in displayRegressed %}
 {% set link = queryLinks[q.hash] %}
 {% if q.site %}{% if link %}[`{{ q.site.name }}`]({{ link }}){% else %}`{{ q.site.name }}`{% endif %}{% else %}{% if link %}[<code>{{ q.queryPreview }}</code>]({{ link }}){% else %}<code>{{ q.queryPreview }}</code>{% endif %}{% endif %}

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -1,4 +1,5 @@
 import type { GateOutcome } from "../gate/evaluate.ts";
+import type { TableGrowth } from "../gate/table-growth.ts";
 import type { CiConclusion, ComputedStats, IndexIdentifier, StatisticsMode } from "@query-doctor/core";
 import type {
   CiRunMetadata,
@@ -144,6 +145,12 @@ export interface ReportContext {
    * roster, so the two cannot disagree (ADR-0009).
    */
   gates?: GateOutcome[];
+  /**
+   * Tables that grew between the baseline and this run. A cost comparison
+   * cannot tell a slower query from a bigger table, so the comment names the
+   * growth rather than leaving the reader to blame their own diff.
+   */
+  tableGrowth?: TableGrowth[];
 }
 
 export interface IndexStatistic {

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -81,6 +81,12 @@ export interface PreviousRun {
   branch: string;
   commitSha: string;
   queries: CiQueryPayload[];
+  /**
+   * The row counts the baseline was planned against. `GET /ci/runs/latest`
+   * has always returned these; the type dropped them, which left the comment
+   * unable to tell a slower query from a bigger table.
+   */
+  computedStats?: ComputedStats;
 }
 
 /**


### PR DESCRIPTION
## Goal

Stop the comment blaming a diff for the database growing. Follow-up to #201 and #205.

## What

Run `019fb8fd` blocked Site#3775, a pull request that changes one markdown file, on 9 cost regressions. The cause was not the diff:

```
project_queries   3,503 -> 6,290 rows   +80%   in the 21 hours since the baseline
```

All 9 read that table. The other 4 movers over threshold read `oauth_tokens`, which grew 28%.

After, the regression gate carries a line above its queries:

```
x Cost regression — 9 queries went up more than 10%, ignoring anything under a cost of 100
      Bigger tables since the baseline: project_queries +80% (3,503 -> 6,290 rows).
      A plan costs more against more rows, whatever the diff changed.

      ProjectQueriesRepository.findByProject
      apps/api/src/projects/project-queries.repository.ts:269:8 · 397,498 on the baseline, 718,215 here (+81%)
```

## How

`src/gate/table-growth.ts` diffs the two runs' `computedStats.reltuples` and returns tables that grew at least 10%, largest first. It returns nothing when either side lacks statistics, which is the case for a run planned on assumptions.

`PreviousRun` gains `computedStats`. `GET /ci/runs/latest` has always returned it — the type dropped it, which is why the comment could not see the growth.

The line states the growth and stops. It does not claim the growth explains any particular query, because the comparison cannot prove that; a reader who sees `project_queries +80%` above nine queries that read `project_queries` can draw it themselves.

## Tests

`table-growth.test.ts` covers the largest-first ordering, ignoring noise under 10%, and returning nothing without statistics. `github.test.ts` covers the line rendering under a fired gate and staying absent when no table grew. Full suite: 393 passing, 40 files, typecheck clean.

## Not in this PR

Per-query attribution. `RegressedQuery` would need `tableReferences`, which `compareRuns` drops the same way it dropped `tags` before #202. That would let the gate soften a regression whose tables grew, rather than only explaining it.