### PR TITLE
refact(gate): name the two cost-floor rules

### DIFF
--- a/src/gate/cost-floor.test.ts
+++ b/src/gate/cost-floor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { comparisonClearsFloor, recommendationClearsFloor } from "./cost-floor.ts";
+
+describe("comparisonClearsFloor", () => {
+  it("reports a move when either side reaches the floor", () => {
+    expect(comparisonClearsFloor(1500, 99, 100)).toBe(true);
+    expect(comparisonClearsFloor(99, 1500, 100)).toBe(true);
+  });
+
+  it("hides a move that stays under the floor on both sides", () => {
+    expect(comparisonClearsFloor(50, 99, 100)).toBe(false);
+    expect(comparisonClearsFloor(99, 50, 100)).toBe(false);
+  });
+
+  it("reports everything when no floor is set", () => {
+    expect(comparisonClearsFloor(1, 2, 0)).toBe(true);
+  });
+});
+
+describe("recommendationClearsFloor", () => {
+  it("needs the base cost to exceed the floor, not merely reach it", () => {
+    expect(recommendationClearsFloor(101, 100)).toBe(true);
+    expect(recommendationClearsFloor(100, 100)).toBe(false);
+  });
+
+  it("reports everything when no floor is set", () => {
+    expect(recommendationClearsFloor(1, 0)).toBe(true);
+  });
+});

--- a/src/gate/cost-floor.ts
+++ b/src/gate/cost-floor.ts
@@ -1,0 +1,47 @@
+// What `minimumCost` means, in the two places it means different things.
+//
+// A repo sets one number. The comparison path and the recommendation path then
+// apply it differently, and neither says so:
+//
+//   comparison      report unless BOTH sides are under the floor
+//   recommendation  report only when the base cost is strictly OVER the floor
+//
+// So with `minimumCost: 100`, a query at 99 that becomes 1500 is a reported
+// regression, a query at 100 with an index recommendation is not reported, and a
+// query moving 50 to 99 is invisible however far it moved in relative terms.
+//
+// This module does not change any of that. It gives both rules a name and a test
+// so the difference is visible in one place, because today it is two inline
+// conditions in two files that look like they should agree.
+//
+// The open question, which needs a product decision rather than a refactor: the
+// comparison rule asks "is this query worth mentioning on either side", and the
+// recommendation rule asks "is the query expensive enough to bother indexing".
+// Those are defensible as separate ideas, but they are configured by one field.
+
+/**
+ * True when a cost change is worth reporting. Mirrors `compareRuns`: a move is
+ * hidden only when the query is under the floor on both sides, so a query that
+ * crosses the floor in either direction is always reported.
+ */
+export function comparisonClearsFloor(
+  previousCost: number,
+  currentCost: number,
+  minimumCost: number,
+): boolean {
+  if (minimumCost <= 0) return true;
+  return !(previousCost < minimumCost && currentCost < minimumCost);
+}
+
+/**
+ * True when an index recommendation is worth showing. Mirrors `runner.ts`, which
+ * uses a strict comparison against the base cost alone — a query costing exactly
+ * the floor is dropped.
+ */
+export function recommendationClearsFloor(
+  baseCost: number,
+  minimumCost: number,
+): boolean {
+  if (minimumCost <= 0) return true;
+  return baseCost > minimumCost;
+}

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -1,3 +1,4 @@
+import { comparisonClearsFloor } from "../gate/cost-floor.ts";
 import { gzip } from "node:zlib";
 import { promisify } from "node:util";
 import * as github from "@actions/github";
@@ -410,10 +411,7 @@ export async function compareRuns(
 
     const changePct = ((currentCost - prevCost) / prevCost) * 100;
     if (changePct > regressionThreshold) {
-      // Skip regressions where both costs are below minimumCost
-      if (minimumCost > 0 && prevCost < minimumCost && currentCost < minimumCost) {
-        continue;
-      }
+      if (!comparisonClearsFloor(prevCost, currentCost, minimumCost)) continue;
       const entry: RegressedQuery = {
         hash: current.hash,
         query: current.query,
@@ -429,10 +427,7 @@ export async function compareRuns(
         regressed.push(entry);
       }
     } else if (changePct < -regressionThreshold) {
-      // Skip improvements where both costs are below minimumCost
-      if (minimumCost > 0 && prevCost < minimumCost && currentCost < minimumCost) {
-        continue;
-      }
+      if (!comparisonClearsFloor(prevCost, currentCost, minimumCost)) continue;
       improved.push({
         hash: current.hash,
         query: current.query,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,3 +1,4 @@
+import { recommendationClearsFloor } from "./gate/cost-floor.ts";
 import * as core from "@actions/core";
 import { PgbadgerSource } from "./sql/pgbadger.ts";
 import type { RecentQuerySource } from "./sql/recent-query.ts";
@@ -170,14 +171,14 @@ export class Runner {
 
     const filteredRecommendations =
       config.minimumCost > 0
-        ? recommendations.filter((r) => r.baseCost > config.minimumCost)
+        ? recommendations.filter((r) => recommendationClearsFloor(r.baseCost, config.minimumCost))
         : recommendations;
     // Kept, not discarded: still shown in the comment (marked below-threshold) so
     // a below-floor query isn't mislabeled "no index suggestion", but excluded
     // from gating and index statistics.
     const belowThresholdRecommendations =
       config.minimumCost > 0
-        ? recommendations.filter((r) => r.baseCost <= config.minimumCost)
+        ? recommendations.filter((r) => !recommendationClearsFloor(r.baseCost, config.minimumCost))
         : [];
     const filteredThresholdWarnings =
       config.minimumCost > 0


### PR DESCRIPTION
## Goal

Make it possible to see what `minimumCost` does. Follow-up to #205, which put the floor in the comment copy and exposed that the number means two different things.

## What

No behaviour changes. Both rules are preserved exactly and now have names, one home, and tests.

Measured against the real `compareRuns` with `threshold=10, minimumCost=100`:

```
1500 -> 99     IMPROVED
99   -> 1500   REGRESSED
50   -> 99     NOT REPORTED
99   -> 50     NOT REPORTED
200  -> 400    REGRESSED
```

The two rules, as they stand:

| path | rule | effect at `minimumCost: 100` |
|---|---|---|
| comparison | hide only when **both** costs are under the floor | `99 -> 1500` reported, `99 -> 50` silent |
| recommendation | show only when base cost is **strictly over** the floor | a query costing exactly 100 is dropped |

## How

`src/gate/cost-floor.ts` holds `comparisonClearsFloor` and `recommendationClearsFloor`. `site-api.ts` and `runner.ts` call them instead of repeating the conditions inline.

## Tests

`cost-floor.test.ts` pins both rules, including the boundaries: a cost exactly at the floor, and a move that stays under it on both sides. Full suite: 393 passing, 40 files, typecheck clean.

## The decision this does not make

The comparison rule asks "is this query worth mentioning at all". The recommendation rule asks "is it expensive enough to bother indexing". Those are reasonable as separate questions, and they are configured by one field, so a repo setting `minimumCost: 100` sets two policies without being told.

There is also a cliff: a query wholly under the floor can move by any factor in silence. At 100 that is trivia. At 10,000 it would hide real movement.

Changing either rule changes which pull requests get blocked, so it belongs in a decision rather than a refactor.