### PR TITLE
fix(github): report table growth per table, capped

### DIFF
--- a/src/gate/table-growth.test.ts
+++ b/src/gate/table-growth.test.ts
@@ -35,3 +35,24 @@ describe("tableGrowth", () => {
     expect(tableGrowth(undefined, stats([["users", 1]]))).toEqual([]);
   });
 });
+
+describe("tables only", () => {
+  it("drops index relations, which mirror their table's row count", () => {
+    const grown = tableGrowth(
+      stats([["oauth_tokens", 111], ["oauth_tokens_pkey", 111]]),
+      stats([["oauth_tokens", 142], ["oauth_tokens_pkey", 142]]),
+      new Set(["oauth_tokens"]),
+    );
+
+    expect(grown.map((g) => g.table)).toEqual(["oauth_tokens"]);
+  });
+
+  it("keeps every relation when no table list is known", () => {
+    const grown = tableGrowth(
+      stats([["oauth_tokens", 111]]),
+      stats([["oauth_tokens", 142]]),
+    );
+
+    expect(grown).toHaveLength(1);
+  });
+});

--- a/src/gate/table-growth.ts
+++ b/src/gate/table-growth.ts
@@ -33,6 +33,12 @@ const MIN_GROWTH_PERCENT = 10;
 export function tableGrowth(
   baseline: RunStats | undefined,
   current: RunStats | undefined,
+  /**
+   * The run's actual tables. `computedStats.reltuples` lists every relation,
+   * including indexes, and an index reports its table's row count — so without
+   * this filter one table that grew is reported once per index on it.
+   */
+  tables?: ReadonlySet<string>,
 ): TableGrowth[] {
   if (!baseline?.reltuples || !current?.reltuples) return [];
 
@@ -45,6 +51,7 @@ export function tableGrowth(
   const grown: TableGrowth[] = [];
   for (const row of current.reltuples) {
     if (row.schema_name !== "public") continue;
+    if (tables && !tables.has(row.relname)) continue;
     const was = before.get(row.relname);
     // A table absent from the baseline has no growth to report, and one that
     // was empty would divide by zero.

--- a/src/main.ts
+++ b/src/main.ts
@@ -275,9 +275,18 @@ async function runInCI(
             config.minimumCost,
           )
         : [];
+      // computedStats lists every relation; statisticsMode carries the table
+      // names, so growth is reported per table rather than once per index.
+      const knownTables =
+        reportContext.statisticsMode.kind === "fromStatisticsExport"
+          ? new Set(
+              reportContext.statisticsMode.stats.map((s) => s.tableName),
+            )
+          : undefined;
       reportContext.tableGrowth = tableGrowth(
         previousRun?.computedStats,
         reportContext.computedStats,
+        knownTables,
       );
       reportContext.gates = evaluateGates(
         {

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -1142,3 +1142,26 @@ describe("branding", () => {
     expect(output).toContain("assets/brand/mark.svg");
   });
 });
+
+describe("table growth is capped", () => {
+  test("names the three biggest and counts the rest", () => {
+    const ctx = makeContext({
+      comparison: makeComparison({
+        regressed: [{ hash: "h1", query: "q", formattedQuery: "SELECT 1", tags: [],
+          previousCost: 200, currentCost: 400, regressionPercentage: 100 }],
+      }),
+      gates: [{ condition: "regression-beyond-threshold", label: "Cost regression", fired: true, conclusion: "failure", found: "1 query went up" }],
+      tableGrowth: [
+        { table: "project_queries", before: 3503, after: 6290, percent: 80 },
+        { table: "oauth_tokens", before: 111, after: 142, percent: 28 },
+        { table: "sessions", before: 12, after: 15, percent: 25 },
+        { table: "project_schemas", before: 584, after: 693, percent: 19 },
+      ],
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("project_queries");
+    expect(output).not.toContain("project_schemas");
+    expect(output).toContain("1 more");
+  });
+});

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -19,7 +19,7 @@
 {% endif %}
 {% if g.condition == "regression-beyond-threshold" and g.fired %}
 {% if tableGrowth and tableGrowth.length > 0 %}
-<sub>Bigger tables since the baseline: {% for gr in tableGrowth %}<code>{{ gr.table }}</code> +{{ gr.percent }}% ({{ formatCost(gr.before) }} → {{ formatCost(gr.after) }} rows){% if not loop.last %}, {% endif %}{% endfor %}. A plan costs more against more rows, whatever the diff changed.</sub>
+<sub>Bigger tables since the baseline: {% for gr in tableGrowth.slice(0, 3) %}<code>{{ gr.table }}</code> +{{ gr.percent }}% ({{ formatCost(gr.before) }} → {{ formatCost(gr.after) }} rows){% if not loop.last %}, {% endif %}{% endfor %}{% if tableGrowth.length > 3 %}, and {{ tableGrowth.length - 3 }} more{% endif %}. A plan costs more against more rows, whatever the diff changed.</sub>
 
 {% endif %}
 {% for q in displayRegressed %}


### PR DESCRIPTION
## Goal

Make the growth line readable and true. Follow-up to #206, caught on its first live run.

## What

Before, on Site#3775:

```
Bigger tables since the baseline: project_queries +80% (3,503 -> 6,290 rows), oauth_tokens +28%
(111 -> 142 rows), oauth_tokens_access_token_hash_idx +28% (111 -> 142 rows), oauth_tokens_pkey
+28% (111 -> 142 rows), oauth_tokens_refresh_token_hash_idx +28% (111 -> 142 rows), ...
```

14 entries for 4 tables. `oauth_tokens_pkey` is an index, and it reports the row count of the table it sits on, so every index on a grown table repeated that table's growth.

After:

```
Bigger tables since the baseline: project_queries +80% (3,503 -> 6,290 rows), oauth_tokens +28%
(111 -> 142 rows), sessions +25% (12 -> 15 rows), and 1 more. A plan costs more against more
rows, whatever the diff changed.
```

## How

`computedStats.reltuples` has no `relkind`, so a relation cannot be classified from that payload alone. The run's `statisticsMode.stats` carries `tableName` for real tables, so `main.ts` builds a set from it and `tableGrowth` filters against it. Without the set the function keeps every relation, which is the behaviour a run planned on assumptions gets.

The template names the three biggest and counts the rest.

## Tests

`table-growth.test.ts` covers dropping an index that mirrors its table, and keeping every relation when no table list is known. `github.test.ts` covers the cap. Full suite: 404 passing, 41 files, typecheck clean.