### PR TITLE
fix(github): close the schema-drift list before the next gate

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -788,6 +788,29 @@ describe("schema change section", () => {
     expect(output).toContain("index (removed)");
   });
 
+  test("closes the schema list so the gates after it are not nested inside it", () => {
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      gates: [
+        { condition: "schema-drift", label: "Schema drift", fired: true, conclusion: "failure", found: "The schema changed against the baseline" },
+        { condition: "high-value-nudge", label: "High-value nudge", fired: false, conclusion: "success", found: "No index or rewrite past the threshold" },
+      ],
+      runMetadata: makeMetadata({
+        schemaChange: { changed: true, operations: [addedTableOp] },
+      }),
+    });
+    const lines = renderTemplate(ctx).split("\n");
+
+    // A line straight after a list item is lazy continuation: markdown folds it
+    // into that `<li>`, so every gate row below renders inside the list.
+    const lastEntry = lines.findLastIndex((l) => l.startsWith("- "));
+    expect(lines[lastEntry + 1]).toBe("");
+
+    // And a line straight after the gate row is a soft break inside the gate's
+    // own paragraph, so the group heading loses the space above it.
+    expect(lines[lines.indexOf("**Added**") - 1]).toBe("");
+  });
+
   test("template renders no schema section when unchanged", () => {
     const ctx = makeContext({
       comparison: makeComparison(),

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -29,12 +29,14 @@
 {% endfor %}
 {% endif %}
 {% if g.condition == "schema-drift" and g.fired and schemaChange.hasChanges %}
+
 {% for group in schemaChange.groups %}
 **{{ schemaChangeHeading(group.kind) }}**
 
 {% for entry in group.entries %}
 - {{ schemaChangeLabel(entry) }}
 {% endfor %}
+
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
### Goal

The PR comment leads with the gate roster, one line per condition, and a condition that fired expands beneath its own line ([ADR-0009](https://github.com/Query-Doctor/Site/blob/staging/docs/adr/0009-the-pr-comment-expands-the-gates-that-fired.md)). On a run where the schema changed, that expansion broke the roster below it. This is the last rendering defect I know of in the gates-first comment.

### What

Before: on a run with schema drift, every gate row after Schema drift rendered as a bullet inside the schema list, indented under the last added constraint. The `Added` and `Removed` group headings also sat flush against the line above them, with a gap only below.

After: the list closes, the gates below it read as their own block, and the group headings have space on both sides.

### How

Both defects are one missing blank line each in `success.md.j2`, and both are markdown rules rather than layout choices. A line straight after a list item is lazy continuation, so markdown folds it into that `<li>`. A line straight after a paragraph is a soft break, so the heading joined the gate row it followed instead of opening its own paragraph.

I confirmed the fix through GitHub's own `/markdown` endpoint rather than by eye: the `<ul>` now closes and the remaining gates come back as a sibling `<p>`.

### Tests

One test in `github.test.ts`, asserting on the rendered markdown: the line after the last schema entry is blank, and so is the line above the group heading. It fails on the old template with the gate row's `<picture>` tag as the actual value, which is the defect itself. Full suite 405 passing, `tsc --noEmit` clean.
