### PR TITLE
ui(github): render schema drift as captions, not a list

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -781,11 +781,11 @@ describe("schema change section", () => {
     });
     const output = renderTemplate(ctx);
 
-    expect(output).toContain("Added");
-    expect(output).toContain("**Added**");
-    expect(output).toContain("table public.orders");
-    expect(output).toContain("**Removed**");
-    expect(output).toContain("index (removed)");
+    // Each line states its own kind, so the block needs no heading above it.
+    expect(output).toContain("<sub>Added table public.orders</sub>");
+    expect(output).toContain("<sub>Removed index</sub>");
+    expect(output).not.toContain("**Added**");
+    expect(output).not.toContain("**Removed**");
   });
 
   test("closes the schema list so the gates after it are not nested inside it", () => {
@@ -800,15 +800,22 @@ describe("schema change section", () => {
       }),
     });
     const lines = renderTemplate(ctx).split("\n");
+    const gateRow = lines.findIndex((l) => l.includes("**Schema drift**"));
+    const entries = lines.filter((l) => l.startsWith("<sub>"));
 
-    // A line straight after a list item is lazy continuation: markdown folds it
-    // into that `<li>`, so every gate row below renders inside the list.
-    const lastEntry = lines.findLastIndex((l) => l.startsWith("- "));
+    // Every expansion sits tight under its gate row, the way the regression and
+    // recommendation blocks do. A blank line here would drop the block further
+    // than any other caption in the comment.
+    expect(lines[gateRow + 1]).toBe(entries[0]);
+
+    // But the block must close, or the roster's leading is computed against a
+    // 12px line box and the next gate row is pulled up tighter than the rest.
+    const lastEntry = lines.lastIndexOf(entries.at(-1)!);
     expect(lines[lastEntry + 1]).toBe("");
 
-    // And a line straight after the gate row is a soft break inside the gate's
-    // own paragraph, so the group heading loses the space above it.
-    expect(lines[lines.indexOf("**Added**") - 1]).toBe("");
+    // Caption size, not body size — otherwise the detail reads as loud as the
+    // gate rows it sits beneath.
+    expect(entries.every((l) => l.endsWith("</sub>"))).toBe(true);
   });
 
   test("template renders no schema section when unchanged", () => {
@@ -830,8 +837,7 @@ describe("schema change section", () => {
       }),
     });
     const output = renderTemplate(ctx);
-    expect(output).toContain("**Added**");
-    expect(output).toContain("table public.orders");
+    expect(output).toContain("<sub>Added table public.orders</sub>");
   });
 });
 

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -21,7 +21,6 @@ import {
 import type { CiQueryPayload, ImprovedQuery, RegressedQuery } from "../site-api.ts";
 import {
   buildSchemaChangeView,
-  schemaChangeHeading,
   schemaChangeLabel,
   type SchemaChangeView,
 } from "./schema-change.ts";
@@ -242,7 +241,6 @@ export function buildViewModel(ctx: ReportContext) {
       hasComparison: false,
       queryLinks,
       schemaChange,
-      schemaChangeHeading,
       schemaChangeLabel,
       modeledTablesNotice,
       gateSummary,
@@ -310,7 +308,6 @@ export function buildViewModel(ctx: ReportContext) {
     hasComparison: true,
     queryLinks,
     schemaChange,
-    schemaChangeHeading,
     schemaChangeLabel,
     modeledTablesNotice,
     gateSummary,

--- a/src/reporters/github/schema-change.test.ts
+++ b/src/reporters/github/schema-change.test.ts
@@ -54,7 +54,7 @@ describe("buildSchemaChangeView", () => {
     const ops: Op[] = [{ op: "remove", path: "/constraints/2" }];
     const view = buildSchemaChangeView(ops);
     const removed = entriesFor(view, "removed");
-    expect(removed).toEqual([{ kind: "removed", object: "constraint", name: "(removed)" }]);
+    expect(removed).toEqual([{ kind: "removed", object: "constraint", name: "" }]);
   });
 
   test("property-level replace is a 'changed' entry carrying the sub-path", () => {
@@ -106,12 +106,12 @@ describe("schemaChangeLabel", () => {
   test("named entry", () => {
     expect(
       schemaChangeLabel({ kind: "added", object: "table", name: "public.users" }),
-    ).toBe("table public.users");
+    ).toBe("Added table public.users");
   });
 
   test("changed entry with detail and no name", () => {
     expect(
       schemaChangeLabel({ kind: "changed", object: "index", name: "", detail: "isUnique" }),
-    ).toBe("index · isUnique");
+    ).toBe("Changed index · isUnique");
   });
 });

--- a/src/reporters/github/schema-change.ts
+++ b/src/reporters/github/schema-change.ts
@@ -119,7 +119,10 @@ function entryFromOp(op: Op): SchemaChangeEntry | null {
     return { kind: "added", object, name: name ?? "(unknown)" };
   }
   if (op.op === "remove" && isElementRoot) {
-    return { kind: "removed", object, name: "(removed)" };
+    // A `remove` op carries no value, so there is no name to print. The line
+    // reads "removed index" — the kind prefix already says what happened, which
+    // the old "(removed)" placeholder was standing in for.
+    return { kind: "removed", object, name: "" };
   }
   // Property-level add/replace, or a nested remove — all "changed" on the object.
   const detail = parsed.rest.length > 0 ? parsed.rest.join(".") : undefined;
@@ -152,18 +155,20 @@ export function buildSchemaChangeView(operations: Op[]): SchemaChangeView {
   };
 }
 
-const KIND_HEADINGS: Record<SchemaChangeKind, string> = {
+const KIND_LABELS: Record<SchemaChangeKind, string> = {
   added: "Added",
   removed: "Removed",
   changed: "Changed",
 };
 
-export function schemaChangeHeading(kind: SchemaChangeKind): string {
-  return KIND_HEADINGS[kind];
-}
-
-/** One-line label for an entry, e.g. "table public.users" or "index users.idx · isUnique". */
+/**
+ * One-line label for an entry, e.g. "Added table public.users" or
+ * "Changed index users.idx · isUnique". Each line states its own kind, so the
+ * entries need no group heading above them — which is what lets the block sit
+ * tight under its gate row the way every other expansion does.
+ */
 export function schemaChangeLabel(entry: SchemaChangeEntry): string {
-  const base = entry.name ? `${entry.object} ${entry.name}` : entry.object;
+  const object = entry.name ? `${entry.object} ${entry.name}` : entry.object;
+  const base = `${KIND_LABELS[entry.kind]} ${object}`;
   return entry.detail ? `${base} · ${entry.detail}` : base;
 }

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -29,15 +29,12 @@
 {% endfor %}
 {% endif %}
 {% if g.condition == "schema-drift" and g.fired and schemaChange.hasChanges %}
-
 {% for group in schemaChange.groups %}
-**{{ schemaChangeHeading(group.kind) }}**
-
 {% for entry in group.entries %}
-- {{ schemaChangeLabel(entry) }}
+<sub>{{ schemaChangeLabel(entry) }}</sub>
+{% endfor %}
 {% endfor %}
 
-{% endfor %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
### Goal

The PR comment leads with the gate roster and expands the conditions that fired ([ADR-0009](https://github.com/Query-Doctor/Site/blob/staging/docs/adr/0009-the-pr-comment-expands-the-gates-that-fired.md)). Schema drift was the one expansion that used a different type scale and a different spacing system from the rest, so a run with schema changes did not look like the same component. This is the last rendering defect I know of in that comment.

### What

Before: a bold `Added` heading, then a bulleted list at body size, then the same for `Removed`. The entries were the same size as the gate rows above them, so a five-entry change read as loud as the checks themselves. On a real run it was 17 entries and it split the six-line roster in half.

After: one line per change, at caption size, tight under the gate row. Each line names its own kind, so `Added table public.statistics_snapshots` replaces the heading-plus-bullet pair.

### How

Read `success.md.j2` first. The schema block now emits `<sub>` lines with a blank line closing it, which is the shape the regression and recommendation blocks already had.

The heading went because each line states its kind, which also retired `schemaChangeHeading` and its plumbing through `github.ts`. A `remove` op carries no value, so its name was the placeholder `(removed)`; with the kind on the line that is redundant and the line is now `Removed index`.

Two spacing facts drove this, both measured in a browser against GitHub's own stylesheet rather than judged by eye. Body text in a comment is 14px and `<sub>` is 10.5px; the schema entries were the only expansion content at 14px. And because those entries shared a paragraph with the gate rows, the roster's line spacing was computed against a smaller line box: 27.1px entering the block and 14.9px leaving it, against a steady 21px elsewhere. The blank line closes the paragraph and the roster returns to 21px.

### Tests

`schema-change.test.ts` covers the label for each kind and the empty name on a remove. `github.test.ts` pins the rendered markdown: entries sit directly under the gate row, the block is closed by a blank line, and every entry is `<sub>`-wrapped. Full suite 405 passing, `tsc --noEmit` clean.

### Not in this PR

On the run that prompted it, 14 of the 17 entries were indexes and constraints belonging to the 3 tables added in the same diff. Filtering those leaves 3 lines. A `changed` entry also renders as `Changed table · columns.17`, where `columns.17` is a JSON Patch array index and means nothing to a reader. Both are content, not layout.