### PR TITLE
fix(gate): stop the untested-data-access gate false-positiving on non-SQL text

### DIFF
--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -40,6 +40,46 @@ describe("patchAddsQueryCode", () => {
     expect(patchAddsQueryCode(addPatch("const total = items.length + 1;"))).toBe(false);
   });
 
+  test("ignores an import of a component named Select", () => {
+    // The Site#3650 false positive: `Select } from "…"` completes the raw
+    // `select … from` shape, so importing a UI component read as a query and
+    // failed the build on a frontend-only PR.
+    expect(
+      patchAddsQueryCode(addPatch('import { Button, Select } from "@query-doctor/ui";')),
+    ).toBe(false);
+  });
+
+  test("ignores a re-export of a component named Select", () => {
+    // Same shape one keyword over. A barrel file re-exporting the component
+    // (packages/ui/src/index.tsx in the Site repo) hits it without an import.
+    expect(
+      patchAddsQueryCode(
+        addPatch('export { default as Select } from "./components/select";'),
+      ),
+    ).toBe(false);
+  });
+
+  test("still detects a query in an exported declaration", () => {
+    // The recall boundary of the re-export rule: `export` starts this line too,
+    // but the statement declares a query rather than re-exporting a binding.
+    expect(
+      patchAddsQueryCode(addPatch('export const q = sql`SELECT id FROM "users"`;')),
+    ).toBe(true);
+  });
+
+  test("ignores prose spanning a JSX block comment", () => {
+    // The Site#3615 false positive: a comment explaining a sort control. Line
+    // stripping missed it twice — the opening line trims to `{/*`, not `/*`,
+    // and the continuation lines are bare prose — leaving "select stay … away
+    // from" to complete the raw select shape.
+    const patch =
+      "@@ -1,0 +1,3 @@\n" +
+      "+        {/* Icon, label and select stay one unwrappable unit: once the label is\n" +
+      "+            hidden the icon is the only thing saying \"sort\", so it must not\n" +
+      "+            wrap away from the control it labels. */}";
+    expect(patchAddsQueryCode(patch)).toBe(false);
+  });
+
   test("ignores DDL keywords in a prose string literal", () => {
     // The Site#3539 false positive: an MCP tool description mentioning the
     // fix it returns. Prose, not a statement — no ON clause, no column list.

--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -323,6 +323,24 @@ describe("evaluateTestPresence", () => {
     expect(verdict).toBeNull();
   });
 
+  test("credits a spec that runs a .sql script from another directory", () => {
+    // The Site#3650 false positive: an operational script under `scripts/` whose
+    // real-DB spec lives under `src/db/` and reads the file back. Different
+    // directory, so only the stem rule can link them, and it compared
+    // `backfill-personal-teams.sql` against `backfill-personal-teams`.
+    const verdict = evaluateTestPresence([
+      changed(
+        "apps/api/scripts/backfill-personal-teams.sql",
+        "INSERT INTO teams (id, name) SELECT gen_random_uuid(), u.name FROM users u;",
+      ),
+      changed(
+        "apps/api/src/db/backfill-personal-teams.spec.ts",
+        'await db.execute(readFileSync("scripts/backfill-personal-teams.sql", "utf8"));',
+      ),
+    ]);
+    expect(verdict).toBeNull();
+  });
+
   test("does not fire on the route-tree regeneration from Site#3614", () => {
     // The reported false positive: a routeTree.gen.ts regeneration (import
     // re-ordering) whose `select-plan` route path read as `SELECT ... FROM`.

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -238,7 +238,10 @@ function baseStem(path: string): string {
   return name
     .replace(/\.(test|spec)\./i, ".")
     .replace(/\.[cm]?[jt]sx?$/i, "")
-    .replace(/\.(py|go|rb)$/i, "");
+    // `.sql` belongs here for a script whose spec reads and runs the file:
+    // `scripts/backfill.sql` ↔ `src/db/backfill.spec.ts`. Leaving it on made the
+    // stem `backfill.sql`, which no test stem can contain (Site#3650).
+    .replace(/\.(py|go|rb|sql)$/i, "");
 }
 
 /**

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -138,6 +138,18 @@ function addedLines(patch: string): string {
     .join("\n");
 }
 
+/**
+ * Drop `/* … *\/` spans before the line rules run. A block comment is only
+ * recognisable line by line when every line is decorated (`*` prefix, JSDoc
+ * style); a JSX `{/* … *\/}` opens with `{` and continues in bare prose, so its
+ * middle lines survived line stripping and "select stay … away from" read as a
+ * query (Site#3615). An unterminated span — a hunk that opens a comment it
+ * doesn't close — is dropped to the end, the gate's usual under-fire side.
+ */
+function stripBlockComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, " ");
+}
+
 /** Drop lines that are plainly comments, so prose mentioning SQL keywords doesn't match. */
 function stripCommentLines(text: string): string {
   return text
@@ -155,13 +167,36 @@ function stripCommentLines(text: string): string {
     .join("\n");
 }
 
+/** `import … from "…"`. */
+const IMPORT_LINE = /^\s*import\s/;
+/**
+ * `export { … } from "…"` / `export * from "…"` — an import that re-exports.
+ * Matched by its own shape rather than a bare `export` prefix so a declaration
+ * like ``export const q = sql`SELECT id FROM "users"` `` is still inspected.
+ */
+const REEXPORT_LINE = /^\s*export\s+(\*|type\s+\{|\{)[^;]*\bfrom\b/;
+
+/**
+ * Drop module-import statements. An import is never a query, but a component
+ * named `Select` puts `Select } from "…"` in the text, which completes the raw
+ * `select … from` shape and reddens a frontend-only PR (Site#3650).
+ */
+function stripImportLines(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !IMPORT_LINE.test(line) && !REEXPORT_LINE.test(line))
+    .join("\n");
+}
+
 /** True when the diff's *added* lines contain query code. */
 export function patchAddsQueryCode(
   patch: string | undefined,
   config: TestPresenceConfig = DEFAULT_TEST_PRESENCE_CONFIG,
 ): boolean {
   if (!patch) return false;
-  const added = stripCommentLines(addedLines(patch));
+  const added = stripImportLines(
+    stripCommentLines(stripBlockComments(addedLines(patch))),
+  );
   return matchesAny(added, config.queryCodePatterns);
 }
 


### PR DESCRIPTION
## Goal

The untested-data-access gate should only fail a build when a PR changes a query that no real-DB test exercises. It is `fail` by default (`packages/core/src/ci/policy.ts:50` in Site), so a false positive blocks a merge that has no data-layer test to add. This PR fixes four false positives reported from dogfooding on our own repo: Query-Doctor/Site#3615 and Query-Doctor/Site#3650.

The precision umbrella is Query-Doctor/Site#3503 (capture-based detection), which replaces this diff heuristic outright. Until that lands, these misfires block merges today. This PR is interim work on the heuristic, not a substitute for #3503.

## What

Before: a frontend-only PR that touched no database could fail the build.

- Query-Doctor/Site#3811 (a mobile CSS pass) was flagged on `apps/app/src/routes/_app/$username/$projectSlug/queries/index.tsx`, a React route component with no SQL, ORM or db import.
- Query-Doctor/Site#3649 (our staging-to-prod merge) was flagged on two `.tsx` components and on two `apps/api/scripts/*.sql` files that each ship a real-DB spec in the same PR.

After: neither PR produces a verdict. Genuine data-access changes are still flagged exactly as before.

## How

Read `src/gate/test-presence.ts` first. The two commits are separate mechanisms and are worth reviewing in order.

**Commit 1 stops non-SQL text reaching the matcher.** Every `.tsx` flag came from one pattern, the raw `select … from` shape, matching ordinary TypeScript:

- `import { Button, Select } from "@query-doctor/ui"` puts `Select } from` in the text. This is a UI component named `Select`, not the react-query `*.queries.ts` import that Query-Doctor/Site#3650 suspected.
- `export { default as Select } from "./components/select"` in a barrel file hits the same shape one keyword over.
- A JSX comment reading "…and select stay one unwrappable unit… must not wrap away from the control it labels" hits it too. Line-based comment stripping missed it twice: the opening line trims to `{/*`, not `/*`, and the continuation lines are bare prose with no `*` decoration. The `quer(y|ies)` content match hypothesised in Query-Doctor/Site#3615 does not exist in the config and was not involved.

The fix strips `/* … */` spans and module imports before matching. The re-export rule keys on `export {` and `export *` rather than a bare `export` prefix, so a declaration like ``export const q = sql`SELECT id FROM "users"` `` is still inspected. That boundary is the one real recall risk in this PR and has its own test.

**Commit 2 credits a spec that lives in another directory.** `baseStem` stripped `.ts`, `.py`, `.go` and `.rb` but not `.sql`, so it compared `backfill-personal-teams.sql` against the spec's `backfill-personal-teams` and found no match. That spec reads the script file and runs it against Postgres. Adding `.sql` widens an already lenient relation, which is the direction the rule documents: a loose match makes the gate under-fire, the safe side.

### What I did not fix

Sweeping every non-test file in Site's `apps/app/src`, `apps/blog/src` and `packages/ui/src` as if fully added, 7 of 415 still classify as data access. All 7 hold SQL as content rather than as a query they run: query fixtures, the rendered `CREATE INDEX CONCURRENTLY ON` recommendation string, planner-node descriptions, demo SQL in a blog component.

No regex separates "SQL text present" from "SQL text executed". The blunt fix Query-Doctor/Site#3650 proposes, excluding frontend `.tsx` from the declared set, would create genuine false negatives, because Next.js server components query databases from `.tsx`. This class is evidence for #3503 rather than something to patch here.

## Tests

Five tests in `src/gate/test-presence.test.ts`, each written before its fix and observed failing first. Four pin a reported false positive. The fifth pins the recall boundary of the re-export rule, and was mutation-checked: it fails under a bare `export`-prefix rule and passes as written.

Full suite 410/410. `npm run typecheck` clean.

Beyond the unit tests, I replayed both PRs' real changed-file lists from the GitHub API through `evaluateTestPresence`. On current `main` the gate fires on 1 file for Query-Doctor/Site#3811 and 4 for Query-Doctor/Site#3649, matching both bug reports exactly. With this branch, both return no verdict.

For recall, I replayed the last 40 merged Site PRs plus those two. Classification drops exactly the three frontend `.tsx` files and keeps all 13 genuine data-access files, so nothing real stopped being detected.

Refs Query-Doctor/Site#3615, Query-Doctor/Site#3650
