### PR TITLE
fix(remote): report what pg_restore printed when schema sync fails

### DIFF
--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -12,6 +12,7 @@ import {
 } from "@query-doctor/core";
 import { type Connectable } from "../sync/connectable.ts";
 import { DumpCommand, RestoreCommand } from "../sync/schema-link.ts";
+import { describeCommandFailure } from "../sync/command-failure.ts";
 import { ConnectionManager } from "../sync/connection-manager.ts";
 import { ExtensionNotInstalledError } from "../sync/errors.ts";
 import { type OptimizedQuery, type RecentQuery } from "../sql/recent-query.ts";
@@ -326,11 +327,18 @@ export class Remote extends EventEmitter<RemoteEvents> {
     source: Connectable,
   ): Promise<void> {
     const dump = DumpCommand.spawn(source, "native-postgres");
-    // is copying up events like this a good idea?
+    // Keep what these emit, not just forward it. The listeners below reach a
+    // websocket the live UI subscribes to, and CI has no such subscriber — so
+    // a failed CI restore reported an exit code while pg_restore had already
+    // named the extension or collation it could not create.
+    const dumpOutput: string[] = [];
+    const restoreOutput: string[] = [];
     dump.on("dump", (data) => {
+      dumpOutput.push(data);
       this.emit("dumpLog", data);
     });
     dump.on("restore", (data) => {
+      restoreOutput.push(data);
       this.emit("restoreLog", data);
     });
 
@@ -340,12 +348,16 @@ export class Remote extends EventEmitter<RemoteEvents> {
     );
     if (!dumpResult.status.success) {
       throw new Error(
-        `Dump failed with status ${dumpResult.status.code}`,
+        describeCommandFailure("pg_dump", dumpResult.status.code, dumpOutput),
       );
     }
     if (restoreResult && !restoreResult.status.success) {
       throw new Error(
-        `Restore failed with status ${restoreResult.status.code}`,
+        describeCommandFailure(
+          "pg_restore",
+          restoreResult.status.code,
+          restoreOutput,
+        ),
       );
     }
   }

--- a/src/sync/command-failure.test.ts
+++ b/src/sync/command-failure.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { describeCommandFailure } from "./command-failure.ts";
+
+describe("describeCommandFailure", () => {
+  test("includes the output the command already produced", () => {
+    // The failure that cost two CI runs on a real repository. pg_restore said
+    // exactly why it failed; the analyzer reported only `status 1`, and the
+    // stderr went to a websocket that CI does not have.
+    const message = describeCommandFailure("pg_restore", 1, [
+      'pg_restore: error: could not execute query: ERROR:  extension "vector" is not available\n',
+      "pg_restore: warning: errors ignored on restore: 16\n",
+    ]);
+
+    expect(message).toContain("pg_restore");
+    expect(message).toContain("status 1");
+    expect(message).toContain('extension "vector" is not available');
+  });
+
+  test("still names the command and code when nothing was captured", () => {
+    const message = describeCommandFailure("pg_dump", 2, []);
+
+    expect(message).toContain("pg_dump");
+    expect(message).toContain("status 2");
+  });
+
+  test("keeps the end of a long output, where the error is", () => {
+    // pg_restore reports per-object errors and then its summary. Truncating
+    // from the end would drop the line that says how the run ended.
+    const noise = Array.from({ length: 500 }, (_, i) => `line ${i}\n`);
+    const message = describeCommandFailure("pg_restore", 1, [
+      ...noise,
+      "pg_restore: warning: errors ignored on restore: 16\n",
+    ]);
+
+    expect(message).toContain("errors ignored on restore: 16");
+    expect(message).not.toContain("line 0\n");
+    expect(message.length).toBeLessThan(4000);
+  });
+
+  test("reports a signal when the command did not exit with a code", () => {
+    const message = describeCommandFailure("pg_restore", null, ["boom\n"]);
+
+    expect(message).toContain("pg_restore");
+    expect(message).toContain("boom");
+  });
+});

--- a/src/sync/command-failure.ts
+++ b/src/sync/command-failure.ts
@@ -1,0 +1,37 @@
+/**
+ * How much of a failed command's output to carry in the thrown error.
+ *
+ * pg_restore reports one line per object it could not create, so a schema with
+ * a missing extension produces hundreds. The cause is in the last of them, and
+ * in the summary line that follows.
+ */
+const MAX_OUTPUT_CHARS = 2000;
+
+/**
+ * Describes a failed child process using the output it already produced.
+ *
+ * The output reaches us as events and was previously forwarded to a websocket,
+ * which the live UI subscribes to and CI does not. A CI job therefore saw
+ * `Restore failed with status 1` and nothing else, while pg_restore had already
+ * printed the missing extension or collation by name. Diagnosing it meant
+ * reproducing the restore by hand outside CI.
+ */
+export function describeCommandFailure(
+  command: string,
+  code: number | null,
+  output: readonly string[],
+): string {
+  const status = code === null ? "no exit code" : `status ${code}`;
+  const captured = tail(output.join(""));
+  if (!captured) {
+    return `${command} failed with ${status}, and produced no output.`;
+  }
+  return `${command} failed with ${status}:\n${captured}`;
+}
+
+/** The end of the output, where the error and the summary are. */
+function tail(output: string): string {
+  const trimmed = output.trimEnd();
+  if (trimmed.length <= MAX_OUTPUT_CHARS) return trimmed;
+  return `[earlier output omitted]\n${trimmed.slice(-MAX_OUTPUT_CHARS)}`;
+}


### PR DESCRIPTION
### Goal

A failed schema sync should say what failed. It reported an exit code, and the explanation it had already captured went to a websocket that CI does not subscribe to. Closes Query-Doctor/Site#3836.

Found by putting four open-source repositories through the agent onboarding flow. Two of them, NetBox and Immich, failed here.

### What

Before:

```
Error: Schema sync failed: Error: Restore failed with status 1
```

That was the only diagnostic in a 1,981-line CI log. Not one line of `pg_restore` output appeared anywhere.

After:

```
Error: Schema sync failed: Error: pg_restore failed with status 1:
pg_restore: connecting to database for restore
pg_restore: creating TABLE "public.testing"
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 217; 1259 16385 TABLE testing test
pg_restore: error: could not execute query: ERROR:  relation "testing" already exists
```

Both blocks above are real output from the same scenario run against this branch and against `main`, not illustrations.

NetBox cost two 11-minute CI runs and was still unexplained afterwards. The cause turned out to be Query-Doctor/Site#2762, open since April: NetBox declares an ICU collation and the analyzer's Postgres is built `--without-icu`. One line of the discarded output would have identified it on the first run.

### How

Read `command-failure.ts` first, then the `pipeSchema` change in `remote.ts`.

`pipeTo` already reads the restore's stderr chunk by chunk and re-emits each one. The only subscriber forwards them to a websocket, which the live UI attaches to and a CI job does not, so the lines were produced and then dropped. `pipeSchema` now keeps them as it forwards them, and hands them to `describeCommandFailure` when the command reports failure.

`describeCommandFailure` keeps the end of the output rather than the start. `pg_restore` prints one line per object it could not create and then a summary, so truncating from the end would drop the line that says how the run finished. The cap is 2000 characters, marked when it applies.

Both the dump and the restore go through it, since a failing dump had the same hole.

### Tests

`command-failure.test.ts` covers the message: it carries the captured output, it still names the command and code when nothing was captured, it keeps the tail of a long output and stays bounded, and it handles a process that exited on a signal rather than a code. The first case uses the exact `pg_restore` text from the Immich failure. I wrote these before the module existed and confirmed them red.

**End-to-end, against real Postgres.** I drove `Remote.syncFrom` through a genuinely failing restore: a source container holding a table, and a target whose `template1` already holds the same table, so the freshly created optimizing database collides on it. On `main` that produced `Restore failed with status 1`. On this branch it produced the block quoted above, naming the object and the reason. Same script, same containers, one file changed between the two runs.

`npm run typecheck` is clean and `src/sync` passes at 42 across 8 files.

### What is not here

That end-to-end check is a script, not a committed test. I tried three times to express it as a vitest case in `remote.test.ts` and it hangs on container startup every time, while the identical sequence completes in about two seconds outside vitest. The neighbouring `syncs correctly` test starts two containers the same way and passes, so this is something specific to that file's harness that I could not pin down in reasonable time. I removed the test rather than commit one that hangs, and I would rather flag the gap than leave a 120-second timeout in the suite.

I also confirmed one thing the original bug report got wrong: `RestoreCommand` already passes `--no-owner --no-acl`, so object ownership is not a failure mode here. The ownership theory in the Site issue's evidence came from a hand-rolled `pg_restore` that did not use the flags this code uses.
