### PR TITLE
feat(reporters): render the API's named schema changes

### DIFF
--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -846,6 +846,35 @@ describe("schema change section", () => {
     expect(entries.every((l) => l.endsWith("</sub>"))).toBe(true);
   });
 
+  // The patch locates this change at /tables/12/columns/17, which is all the
+  // reporter could print from it. The API now names it, so the position never
+  // reaches the comment.
+  test("renders the API's named changes rather than the patch path", () => {
+    const addedColumnOp = {
+      op: "add" as const,
+      path: "/tables/12/columns/17",
+      value: { type: "column", name: "statistics_payload_id", order: 18 },
+    };
+    const ctx = makeContext({
+      comparison: makeComparison(),
+      comparisonBranch: "main",
+      gates: [{ condition: "schema-drift", label: "Schema drift", fired: true, conclusion: "failure", found: "The schema changed against the baseline" }],
+      runMetadata: makeMetadata({
+        schemaChange: {
+          changed: true,
+          operations: [addedColumnOp],
+          changes: [
+            { kind: "added" as const, object: "column", name: "public.ci_runs.statistics_payload_id" },
+          ],
+        },
+      }),
+    });
+    const output = renderTemplate(ctx);
+
+    expect(output).toContain("<sub>Added column public.ci_runs.statistics_payload_id</sub>");
+    expect(output).not.toContain("columns.17");
+  });
+
   test("template renders no schema section when unchanged", () => {
     const ctx = makeContext({
       comparison: makeComparison(),

--- a/src/reporters/github/github.ts
+++ b/src/reporters/github/github.ts
@@ -20,6 +20,7 @@ import {
 
 import type { CiQueryPayload, ImprovedQuery, RegressedQuery } from "../site-api.ts";
 import {
+  buildNamedSchemaChangeView,
   buildSchemaChangeView,
   schemaChangeLabel,
   type SchemaChangeView,
@@ -160,7 +161,13 @@ function buildSchemaChange(ctx: ReportContext): SchemaChangeView {
   if (!change || !change.changed) {
     return { hasChanges: false, total: 0, groups: [] };
   }
-  return buildSchemaChangeView(change.operations);
+  // The API names each changed object; a patch path indexes a baseline schema
+  // this process never holds, so it can only be read positionally. Prefer the
+  // names whenever the API sends them, and fall back to the patch for an API
+  // that predates the field.
+  return change.changes
+    ? buildNamedSchemaChangeView(change.changes)
+    : buildSchemaChangeView(change.operations);
 }
 
 /**

--- a/src/reporters/github/schema-change.test.ts
+++ b/src/reporters/github/schema-change.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from "vitest";
 import type { Op } from "jsondiffpatch/formatters/jsonpatch";
 import {
+  buildNamedSchemaChangeView,
   buildSchemaChangeView,
   schemaChangeLabel,
   type SchemaChangeKind,
@@ -99,6 +100,41 @@ describe("buildSchemaChangeView", () => {
     const view = buildSchemaChangeView(ops);
     expect(view.total).toBe(3);
     expect(view.groups.map((g) => g.kind)).toEqual(["added", "removed", "changed"]);
+  });
+});
+
+describe("buildNamedSchemaChangeView", () => {
+  test("groups the API's named changes by kind", () => {
+    const view = buildNamedSchemaChangeView([
+      { kind: "changed", object: "table", name: "public.events", properties: ["partitionKeyDef"] },
+      { kind: "added", object: "column", name: "public.ci_runs.statistics_payload_id" },
+      { kind: "removed", object: "index", name: "public.users.users_email_idx" },
+    ]);
+
+    expect(view.total).toBe(3);
+    expect(view.groups.map((g) => g.kind)).toEqual(["added", "removed", "changed"]);
+  });
+
+  test("renders the changed properties as the entry's detail", () => {
+    const view = buildNamedSchemaChangeView([
+      {
+        kind: "changed",
+        object: "column",
+        name: "public.users.email",
+        properties: ["columnType", "isNullable"],
+      },
+    ]);
+
+    expect(schemaChangeLabel(view.groups[0]!.entries[0]!)).toBe(
+      "Changed column public.users.email · columnType, isNullable",
+    );
+  });
+
+  // The API derives `changed` from the patch, which still counts differences the
+  // named list drops — an oid that moved because the two snapshots came from
+  // different databases. Render nothing rather than invent a line for it.
+  test("an empty list renders nothing", () => {
+    expect(buildNamedSchemaChangeView([]).hasChanges).toBe(false);
   });
 });
 

--- a/src/reporters/github/schema-change.ts
+++ b/src/reporters/github/schema-change.ts
@@ -1,4 +1,5 @@
 import type { Op } from "jsondiffpatch/formatters/jsonpatch";
+import type { NamedSchemaChange } from "../site-api.ts";
 
 export type SchemaChangeKind = "added" | "removed" | "changed";
 
@@ -153,6 +154,40 @@ export function buildSchemaChangeView(operations: Op[]): SchemaChangeView {
     total,
     groups,
   };
+}
+
+/**
+ * The view built from the API's named changes. Nothing is inferred here: the
+ * API compared the two schemas and says which object changed, so this only
+ * groups the entries the way the patch-derived view does.
+ */
+export function buildNamedSchemaChangeView(
+  changes: NamedSchemaChange[],
+): SchemaChangeView {
+  const byKind: Record<SchemaChangeKind, SchemaChangeEntry[]> = {
+    added: [],
+    removed: [],
+    changed: [],
+  };
+
+  for (const change of changes) {
+    byKind[change.kind].push({
+      kind: change.kind,
+      object: change.object,
+      name: change.name,
+      detail: change.properties?.length
+        ? change.properties.join(", ")
+        : undefined,
+    });
+  }
+
+  const groups: SchemaChangeGroup[] = KIND_ORDER
+    .map((kind) => ({ kind, entries: byKind[kind] }))
+    .filter((g) => g.entries.length > 0);
+
+  const total = groups.reduce((sum, g) => sum + g.entries.length, 0);
+
+  return { hasChanges: total > 0, total, groups };
 }
 
 const KIND_LABELS: Record<SchemaChangeKind, string> = {

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -91,6 +91,19 @@ export interface PreviousRun {
 }
 
 /**
+ * One object the API found changed between this run's schema and its baseline,
+ * already named. `name` is qualified, e.g.
+ * `public.ci_runs.statistics_payload_id`, and `properties` lists the fields that
+ * differ on a `changed` entry.
+ */
+export interface NamedSchemaChange {
+  kind: "added" | "removed" | "changed";
+  object: string;
+  name: string;
+  properties?: string[];
+}
+
+/**
  * Unified CI-signal metadata returned by `POST /ci/runs` (Site #3067).
  * The analyzer renders these fields verbatim so the PR comment speaks the same
  * language as the Slack/webhook alert. See analyzer#141.
@@ -139,7 +152,10 @@ export interface CiRunMetadata {
    * for the resolved comparison baseline — the same baseline the roll-up uses,
    * so the schema diff and the query signals agree on what "the target branch"
    * is. `operations` is a jsondiffpatch JSON Patch (RFC 6902) over the
-   * {@link FullSchema} shape, keyed by table/index/constraint OID server-side.
+   * {@link FullSchema} shape. `changes` is the same delta with every object
+   * named, which is what the comment renders; only the API can produce it,
+   * because a patch path indexes a baseline schema this process never holds.
+   * It is absent on a Site API that predates it, and the patch is the fallback.
    *
    * Optional/nullable to mirror {@link baseline}: absent on a Site API that
    * predates this field (deploy skew — render nothing), `null` when the API
@@ -149,6 +165,7 @@ export interface CiRunMetadata {
   schemaChange?: {
     changed: boolean;
     operations: Op[];
+    changes?: NamedSchemaChange[];
   } | null;
 }
 


### PR DESCRIPTION
### Goal

Pairs with Query-Doctor/Site#3855, which is the other half. A PR that adds one column should have the CI comment name that column.

This is the rendering half. Site computes the named list; this reads it. Merge Site first, or this changes nothing.

### What

Before, a change inside an object printed as a patch path. On Site#3794, which adds `ci_runs.statistics_payload_id`, the comment said:

```
Changed table · columns.17
```

After, the same run reads:

```
Added column public.ci_runs.statistics_payload_id
```

The positional churn goes with it. Site's summary drops a column's `attnum` and every `oid`, so the `· columns.3.order` and `· oid` lines stop appearing.

### How

`buildSchemaChange` in `github.ts` prefers `metadata.schemaChange.changes` and falls back to `buildSchemaChangeView(operations)`. `entryFromOp` is untouched, so an API that predates the field renders as it does today.

`buildNamedSchemaChangeView` in `schema-change.ts` only groups what the API sends. It infers nothing, because the inference is what produced the path in the first place: `/tables/12` indexes a baseline schema this process never holds.

`properties` renders as the entry's detail, so a column that changed type reads `Changed column public.users.email · columnType, isNullable`.

An empty `changes` with `changed: true` renders nothing. Site derives `changed` from the patch, which still counts an oid that moved because the two snapshots came from different databases. That case leaves the gate row with nothing under it, which is worse than it sounds: the gate says the schema changed and lists no evidence. Site#3855 asks whether the gate should follow `changes` instead. This PR does not decide it.

### Tests

`github.test.ts` renders a run whose metadata carries both the patch and the named list, and asserts the comment contains the column's name and not `columns.17`. It fails on main with the exact string this fixes.

`schema-change.test.ts` covers grouping by kind, `properties` as detail, and the empty list. The existing patch-path tests are unchanged and still pass, which is the fallback.

Full suite 425 passed across 43 files. `npm run typecheck` clean.
