### PR TITLE
fix(gate): count a tests/pg suite as a data-layer test

### DIFF
--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -259,6 +259,16 @@ describe("classifyChangedFiles", () => {
     expect(surface.dataAccessChanged).toEqual([]);
   });
 
+  test("does not read `pg` inside another word as a real-Postgres suite", () => {
+    // The recall boundary of the `pg/` rule: `upgrade` contains `pg`, so an
+    // unanchored pattern would silently credit unrelated suites as data-layer
+    // coverage and make the gate miss genuinely untested queries.
+    const surface = classifyChangedFiles([
+      changed("tests/upgrade/upgrade.test.ts", "expect(migrate(config)).toBe(true);"),
+    ]);
+    expect(surface.dataLayerTestChanged).toEqual([]);
+  });
+
   test("still flags a raw SELECT ... FROM query in application code", () => {
     // The tightened `select`-shape must keep its recall: real SQL has whitespace
     // after the keyword. This trips only the raw select shape (no `db.`, no
@@ -318,6 +328,24 @@ describe("evaluateTestPresence", () => {
       changed(
         "tests/pg/postgres.test.ts",
         "expect(await db.select().from(projects)).toEqual([p]);",
+      ),
+    ]);
+    expect(verdict).toBeNull();
+  });
+
+  test("credits a tests/pg suite covering a changed query file (#3550)", () => {
+    // The reported false positive: `src/db/postgres.ts` gained two repo methods
+    // and the same PR added the pg test that exercises them. The test's own added
+    // line calls the repo rather than a query builder, so nothing in its content
+    // marks it as data-layer; only its path can, and `tests/pg/` said nothing.
+    const verdict = evaluateTestPresence([
+      changed(
+        "src/db/postgres.ts",
+        "const rows = await db.select().from(projects).where(eq(projects.userId, id));",
+      ),
+      changed(
+        "tests/pg/postgres.test.ts",
+        "expect(await db.projects.findByUser(u)).toEqual([p]);",
       ),
     ]);
     expect(verdict).toBeNull();

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -103,6 +103,9 @@ export const DEFAULT_TEST_PRESENCE_CONFIG: TestPresenceConfig = {
     /\.repo\./i,
     /integration/i,
     /(^|\/)(dal|data-access)\//i,
+    // A `pg/` directory is the common name for a real-Postgres suite (Site#3550).
+    // Anchored to a whole path segment: a bare `pg` would match `upgrade`.
+    /(^|\/)pg\//i,
   ],
   migrationFilePatterns: [
     /(^|\/)migrations?\/.*\.sql$/i, // .../migrations/**/*.sql (Rails, Prisma, ...)


### PR DESCRIPTION
## Goal

The untested-data-access gate should pass when a PR changes a query and adds the real-DB test that exercises it. Query-Doctor/Site#3550 reported it failing that case, which is the central path the gate promises to handle. This is the last of the dogfooding false positives in that family; Query-Doctor/analyzer#214 fixed the other four.

The precision umbrella is Query-Doctor/Site#3503 (capture-based detection), which replaces this diff heuristic. This is interim work on the heuristic.

## What

Before: a PR that changed `src/db/postgres.ts` and added `tests/pg/postgres.test.ts` in the same diff was told the query file had no related data-layer test.

After: it passes.

## How

`isDataLayerTest` credits a changed test one of two ways: its own added lines contain query code, or its path looks like a data-layer test. Neither fired here. The added line called the repo method (`db.projects.findByUser`) rather than a query builder, so the content check said nothing. `dataLayerTestPathPatterns` matched `repositor`, `.repo.`, `integration` and `dal|data-access`, but had no entry for `pg`.

So the test was dropped from `dataLayerTestChanged` entirely, and the changed query file had nothing left to be related to.

The stem rule that Query-Doctor/Site#3550 blames was never reached. It compares `postgres` against `postgres` and would have linked the two files.

The fix adds a `pg/` directory pattern. It is anchored to a whole path segment, because a bare `pg` also matches `upgrade`, and an unanchored version would credit unrelated suites as data-layer coverage and make the gate miss genuinely untested queries. A test pins that boundary.

### Why this was not caught in production

The reported run passed the gate anyway, because the capture override suppresses the verdict when the run captured new query hashes. That mask does not hold on a first run, or on any PR with no baseline to diff against, where capture is empty. Closing Query-Doctor/Site#3550 on the strength of that override would have buried the bug.

## Tests

Two tests in `src/gate/test-presence.test.ts`, both written before the fix and observed failing first where applicable:

- `credits a tests/pg suite covering a changed query file (#3550)` reproduces the report at the `evaluateTestPresence` seam. Red before the change, green after.
- `does not read pg inside another word as a real-Postgres suite` pins the anchor. It was mutation-checked: it fails under a bare `/pg/i` and passes anchored.

Full suite 423/423. `npm run typecheck` clean.

Replaying the reported scenario with no capture argument, the gate fires before this change and returns no verdict after. Re-running the classification sweep over 42 Site PRs, the set of files classified as data access is unchanged, so nothing stopped being detected.

Refs Query-Doctor/Site#3550
