### PR TITLE
feat(gate): explain why a file was flagged

### DIFF
--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   classifyChangedFiles,
   evaluateTestPresence,
+  findQueryCode,
   patchAddsQueryCode,
   type ChangedFile,
 } from "./test-presence.ts";
@@ -16,6 +17,50 @@ const changed = (
   line: string,
   status = "modified",
 ): ChangedFile => ({ path, status, patch: addPatch(line) });
+
+describe("findQueryCode", () => {
+  test("names the rule that matched and the line it matched on", () => {
+    // Every false positive so far has been diagnosed by rebuilding this by hand:
+    // which rule fired, on what text. The gate has it and used to discard it.
+    const patch =
+      "@@ -1,0 +1,3 @@\n" +
+      "+const label = 'sort';\n" +
+      "+const q = sql`SELECT id FROM users`;\n" +
+      "+return q;";
+    expect(findQueryCode(patch)).toMatchObject({
+      rule: "drizzle-sql-tag",
+      line: 2,
+    });
+  });
+
+  test("prefers the more specific rule when several match", () => {
+    // Rule order is precedence. `.execute(` names the cause better than the
+    // raw select shape that also matches this line.
+    expect(
+      findQueryCode(addPatch("await db.execute(sql`SELECT id FROM users`);")),
+    ).toMatchObject({ rule: "execute-or-query-call", line: 1 });
+  });
+
+  test("reports the line a comment-stripped match sits on", () => {
+    // Blanking rather than deleting is what keeps this line number honest: the
+    // three comment lines above still occupy their positions.
+    const patch =
+      "@@ -1,0 +1,5 @@\n" +
+      "+// a comment\n" +
+      "+// another comment\n" +
+      "+import { Select } from '@query-doctor/ui';\n" +
+      "+\n" +
+      "+const rows = await db.select().from(users);";
+    expect(findQueryCode(patch)).toMatchObject({
+      rule: "db-query-method",
+      line: 5,
+    });
+  });
+
+  test("is null when no rule matches", () => {
+    expect(findQueryCode(addPatch("const total = items.length + 1;"))).toBeNull();
+  });
+});
 
 describe("patchAddsQueryCode", () => {
   test("detects an ORM query call in added lines", () => {

--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -248,14 +248,14 @@ describe("classifyChangedFiles", () => {
     const surface = classifyChangedFiles([
       changed("apps/api/src/users/user.service.ts", "return db.select().from(users);"),
     ]);
-    expect(surface.dataAccessChanged).toEqual(["apps/api/src/users/user.service.ts"]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual(["apps/api/src/users/user.service.ts"]);
   });
 
   test("does NOT flag a comment-only edit to a repository file", () => {
     const surface = classifyChangedFiles([
       changed("apps/api/src/users/user.repository.ts", "// clarify the join order"),
     ]);
-    expect(surface.dataAccessChanged).toEqual([]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual([]);
   });
 
   test("classes a query-bearing test as a data-layer test", () => {
@@ -268,21 +268,21 @@ describe("classifyChangedFiles", () => {
     expect(surface.dataLayerTestChanged).toEqual([
       "apps/api/src/users/user.repository.spec.ts",
     ]);
-    expect(surface.dataAccessChanged).toEqual([]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual([]);
   });
 
   test("falls back to the filename prior when a patch is unavailable", () => {
     const surface = classifyChangedFiles([
       { path: "apps/api/src/users/user.repository.ts", status: "modified" },
     ]);
-    expect(surface.dataAccessChanged).toEqual(["apps/api/src/users/user.repository.ts"]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual(["apps/api/src/users/user.repository.ts"]);
   });
 
   test("does not count a removed file as a change", () => {
     const surface = classifyChangedFiles([
       changed("apps/api/src/users/user.repository.ts", "db.select().from(users)", "removed"),
     ]);
-    expect(surface.dataAccessChanged).toEqual([]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual([]);
   });
 
   test("does NOT class a Drizzle migration .sql as changed data-access", () => {
@@ -293,7 +293,7 @@ describe("classifyChangedFiles", () => {
         "CREATE TABLE projects (id uuid PRIMARY KEY);",
       ),
     ]);
-    expect(surface.dataAccessChanged).toEqual([]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual([]);
   });
 
   test("excludes migration .sql under a migrations/ directory too", () => {
@@ -303,7 +303,7 @@ describe("classifyChangedFiles", () => {
         "ALTER TABLE plans ADD COLUMN project_id uuid;",
       ),
     ]);
-    expect(surface.dataAccessChanged).toEqual([]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual([]);
   });
 
   test("still classes DDL inside a .ts source file as data-access", () => {
@@ -314,7 +314,7 @@ describe("classifyChangedFiles", () => {
         "await db.execute(sql`CREATE TABLE projects (id uuid)`);",
       ),
     ]);
-    expect(surface.dataAccessChanged).toEqual(["apps/api/src/schema.ts"]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual(["apps/api/src/schema.ts"]);
   });
 
   test("does not read a `select-plan` route path as a SELECT ... FROM query", () => {
@@ -331,7 +331,7 @@ describe("classifyChangedFiles", () => {
           "+import { Route as MembershipRegisterRouteImport } from './routes/membership/register'",
       },
     ]);
-    expect(surface.dataAccessChanged).toEqual([]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual([]);
   });
 
   test("does not read `pg` inside another word as a real-Postgres suite", () => {
@@ -351,7 +351,7 @@ describe("classifyChangedFiles", () => {
     const surface = classifyChangedFiles([
       changed("apps/api/src/reports.ts", "const sql = `SELECT id, name FROM users`;"),
     ]);
-    expect(surface.dataAccessChanged).toEqual(["apps/api/src/reports.ts"]);
+    expect(surface.dataAccessChanged.map((f) => f.path)).toEqual(["apps/api/src/reports.ts"]);
   });
 });
 
@@ -363,8 +363,36 @@ describe("evaluateTestPresence", () => {
     expect(verdict).toMatchObject({
       condition: "untested-data-access",
       verdictClass: "uncertain-conservative-flag",
-      dataAccessFiles: ["apps/api/src/users/user.repository.ts"],
+      dataAccessFiles: [
+        {
+          path: "apps/api/src/users/user.repository.ts",
+          evidence: { rule: "db-query-method", line: 1, matched: "db.insert" },
+        },
+      ],
     });
+  });
+
+  test("carries the evidence into the verdict a reader sees", () => {
+    // The point of the whole change: a reader can judge the flag from the PR
+    // comment, without cloning the analyzer to find out which rule fired.
+    const verdict = evaluateTestPresence([
+      changed("apps/api/src/db/test-db.ts", "const db = drizzle(pool);"),
+    ]);
+    expect(verdict?.dataAccessFiles[0]).toEqual({
+      path: "apps/api/src/db/test-db.ts",
+      evidence: { rule: "drizzle-init", line: 1, matched: "drizzle(" },
+    });
+  });
+
+  test("omits evidence when the path prior decided it", () => {
+    // A large or binary file arrives with no patch, so there is no matched text
+    // to show. The flag stands on the filename alone and says so by omission.
+    const verdict = evaluateTestPresence([
+      { path: "apps/api/src/users/user.repository.ts", status: "modified" },
+    ]);
+    expect(verdict?.dataAccessFiles).toEqual([
+      { path: "apps/api/src/users/user.repository.ts" },
+    ]);
   });
 
   test("passes when a related data-layer test changes alongside the query", () => {
@@ -386,7 +414,7 @@ describe("evaluateTestPresence", () => {
         "expect(await db.select().from(users)).toEqual([u]);",
       ),
     ]);
-    expect(verdict?.dataAccessFiles).toEqual([
+    expect(verdict?.dataAccessFiles.map((f) => f.path)).toEqual([
       "apps/api/src/orders/order.repository.ts",
     ]);
   });
@@ -539,6 +567,8 @@ describe("evaluateTestPresence", () => {
       [changed("src/db/postgres.ts", "return db.select().from(projects);")],
       { newQueryHashes: [] },
     );
-    expect(verdict?.dataAccessFiles).toEqual(["src/db/postgres.ts"]);
+    expect(verdict?.dataAccessFiles.map((f) => f.path)).toEqual([
+      "src/db/postgres.ts",
+    ]);
   });
 });

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -50,36 +50,55 @@ const SOURCE_FILE_PATTERNS = [
 // high-precision ORM / query-builder calls; a small set of raw-SQL shapes
 // catches string queries. Comment lines are stripped before matching, so a
 // code comment mentioning "select" won't trip it.
-const QUERY_CODE_PATTERNS = [
-  /\bdb\.(select|insert|update|delete)\b/i,
-  /\.(execute|query)\s*\(/i,
-  /\bsql`/, // drizzle sql`...` tag
-  /\bdrizzle\s*\(/i,
-  /\bknex\b/i,
-  /\bprisma\.\w+\.(find\w*|create|update|delete|upsert|count|aggregate)\b/i,
-  /\.createQueryBuilder\s*\(/i,
-  /\bgetRepository\s*\(/i,
-  /\.\$(queryRaw|executeRaw)/,
-  /\.(leftJoin|innerJoin|rightJoin)\s*\(/i,
-  /\binsert\s+into\b/i,
-  /\bdelete\s+from\b/i,
-  /\bupdate\b[^\n]{0,80}\bset\b/i,
-  // `select` must be followed by whitespace, as real `SELECT … FROM` is — so a
+// Each rule carries a stable name. The name is the whole point: it is what a
+// reader sees when the gate flags their file, and what a bug report can cite.
+// Six precision fixes so far were each diagnosed by rebuilding, by hand, which
+// of these fired and on what text.
+const QUERY_CODE_RULES: { name: string; pattern: RegExp }[] = [
+  { name: "db-query-method", pattern: /\bdb\.(select|insert|update|delete)\b/i },
+  { name: "execute-or-query-call", pattern: /\.(execute|query)\s*\(/i },
+  { name: "drizzle-sql-tag", pattern: /\bsql`/ },
+  { name: "drizzle-init", pattern: /\bdrizzle\s*\(/i },
+  { name: "knex", pattern: /\bknex\b/i },
+  {
+    name: "prisma-model-call",
+    pattern: /\bprisma\.\w+\.(find\w*|create|update|delete|upsert|count|aggregate)\b/i,
+  },
+  { name: "typeorm-query-builder", pattern: /\.createQueryBuilder\s*\(/i },
+  { name: "typeorm-get-repository", pattern: /\bgetRepository\s*\(/i },
+  { name: "prisma-raw", pattern: /\.\$(queryRaw|executeRaw)/ },
+  { name: "builder-join", pattern: /\.(leftJoin|innerJoin|rightJoin)\s*\(/i },
+  { name: "raw-insert-into", pattern: /\binsert\s+into\b/i },
+  { name: "raw-delete-from", pattern: /\bdelete\s+from\b/i },
+  { name: "raw-update-set", pattern: /\bupdate\b[^\n]{0,80}\bset\b/i },
+  // `select` must be followed by whitespace, as real `SELECT … FROM` is, so a
   // hyphenated route segment like `select-plan` (whose `\bselect\b` boundary is
   // the hyphen) doesn't read as a query when an import `from` follows it
   // (Site#3615).
-  /\bselect\s[\s\S]{0,300}?\bfrom\b/i,
+  { name: "raw-select-from", pattern: /\bselect\s[\s\S]{0,300}?\bfrom\b/i },
   // DDL is matched by statement shape (ON clause, column list, target
-  // identifier), not bare keyword adjacency: prose in a string literal —
-  // "its suggested CREATE INDEX fix" in an MCP tool description (Site#3539)
-  // — must not read as a query. Stripping string literals instead would
-  // blind the raw-SQL shapes above, since raw SQL lives in strings; the
-  // statement's own grammar is the discriminator.
-  /\bcreate\s+(unique\s+)?index\b[^\n]{0,120}?\bon\b/i,
-  /\bcreate\s+table\b[^\n]{0,80}?\(/i,
-  /\bcreate\s+(or\s+replace\s+)?(materialized\s+)?view\b[^\n]{0,80}?\bas\b/i,
-  /\balter\s+table\s+(if\s+exists\s+)?["\w]/i,
-  /\bdrop\s+(table|index|view|materialized\s+view)\s+(if\s+exists\s+|concurrently\s+)?["\w]/i,
+  // identifier), not bare keyword adjacency: prose in a string literal, such as
+  // "its suggested CREATE INDEX fix" in an MCP tool description (Site#3539),
+  // must not read as a query. Stripping string literals instead would blind the
+  // raw-SQL shapes above, since raw SQL lives in strings; the statement's own
+  // grammar is the discriminator.
+  {
+    name: "ddl-create-index",
+    pattern: /\bcreate\s+(unique\s+)?index\b[^\n]{0,120}?\bon\b/i,
+  },
+  { name: "ddl-create-table", pattern: /\bcreate\s+table\b[^\n]{0,80}?\(/i },
+  {
+    name: "ddl-create-view",
+    pattern: /\bcreate\s+(or\s+replace\s+)?(materialized\s+)?view\b[^\n]{0,80}?\bas\b/i,
+  },
+  {
+    name: "ddl-alter-table",
+    pattern: /\balter\s+table\s+(if\s+exists\s+)?["\w]/i,
+  },
+  {
+    name: "ddl-drop",
+    pattern: /\bdrop\s+(table|index|view|materialized\s+view)\s+(if\s+exists\s+|concurrently\s+)?["\w]/i,
+  },
 ];
 
 /** Fallback data-access signal, used only when a file's patch is unavailable. */
@@ -141,15 +160,24 @@ function addedLines(patch: string): string {
 }
 
 /**
- * Drop `/* … *\/` spans before the line rules run. A block comment is only
+ * Blank out `/* … *\/` spans before the line rules run. A block comment is only
  * recognisable line by line when every line is decorated (`*` prefix, JSDoc
  * style); a JSX `{/* … *\/}` opens with `{` and continues in bare prose, so its
  * middle lines survived line stripping and "select stay … away from" read as a
- * query (Site#3615). An unterminated span — a hunk that opens a comment it
- * doesn't close — is dropped to the end, the gate's usual under-fire side.
+ * query (Site#3615). An unterminated span, a hunk that opens a comment it does
+ * not close, is blanked to the end, the gate's usual under-fire side.
+ *
+ * Every stripper here replaces text with spaces rather than removing it, so an
+ * offset into the stripped text still points at the same line of the original.
+ * That is what lets a match report the line it was found on.
  */
 function stripBlockComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, " ");
+  return text.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, blankOut);
+}
+
+/** Replace every character except newlines with a space. */
+function blankOut(text: string): string {
+  return text.replace(/[^\n]/g, " ");
 }
 
 /**
@@ -162,25 +190,24 @@ function stripBlockComments(text: string): string {
 const TRAILING_COMMENT = /(?<![:/])(\/\/|--).*$/;
 
 /**
- * Drop comments, so prose mentioning SQL keywords doesn't match. Whole-line
- * comments go entirely; a comment trailing code takes only the tail. The gate
+ * Blank comments, so prose mentioning SQL keywords doesn't match. A whole-line
+ * comment goes entirely; a comment trailing code takes only the tail. The gate
  * flagged its own source before this handled the trailing case: a rule defined
  * as ``/\bsql`/, // drizzle sql`...` tag`` matched the comment, not the code.
  */
 function stripCommentLines(text: string): string {
   return text
     .split("\n")
-    .filter((line) => {
+    .map((line) => {
       const trimmed = line.trim();
-      return !(
+      const isComment =
         trimmed.startsWith("//") ||
         trimmed.startsWith("*") ||
         trimmed.startsWith("/*") ||
         trimmed.startsWith("#") ||
-        trimmed.startsWith("--")
-      );
+        trimmed.startsWith("--");
+      return isComment ? blankOut(line) : line.replace(TRAILING_COMMENT, blankOut);
     })
-    .map((line) => line.replace(TRAILING_COMMENT, ""))
     .join("\n");
 }
 
@@ -194,26 +221,62 @@ const IMPORT_LINE = /^\s*import\s/;
 const REEXPORT_LINE = /^\s*export\s+(\*|type\s+\{|\{)[^;]*\bfrom\b/;
 
 /**
- * Drop module-import statements. An import is never a query, but a component
+ * Blank module-import statements. An import is never a query, but a component
  * named `Select` puts `Select } from "…"` in the text, which completes the raw
  * `select … from` shape and reddens a frontend-only PR (Site#3650).
  */
 function stripImportLines(text: string): string {
   return text
     .split("\n")
-    .filter((line) => !IMPORT_LINE.test(line) && !REEXPORT_LINE.test(line))
+    .map((line) =>
+      IMPORT_LINE.test(line) || REEXPORT_LINE.test(line) ? blankOut(line) : line,
+    )
     .join("\n");
 }
 
-/** True when the diff's *added* lines contain query code. */
-export function patchAddsQueryCode(
+/** Why a file reads as a query site: which rule matched, where, and on what. */
+export interface QuerySiteEvidence {
+  /** Stable rule name, e.g. `raw-select-from`. */
+  rule: string;
+  /** 1-indexed line within the patch's added lines. */
+  line: number;
+  /** The matched text, collapsed to one line and trimmed for display. */
+  matched: string;
+}
+
+/** How much matched text to carry into the verdict. */
+const MATCH_EXCERPT_LIMIT = 120;
+
+/**
+ * The first rule that matches the diff's added lines, with the line it matched
+ * on. Rule order is precedence: the earlier, higher-precision ORM shapes win
+ * over the broad raw-SQL ones, so the evidence names the most specific cause.
+ */
+export function findQueryCode(
   patch: string | undefined,
-): boolean {
-  if (!patch) return false;
+): QuerySiteEvidence | null {
+  if (!patch) return null;
   const added = stripImportLines(
     stripCommentLines(stripBlockComments(addedLines(patch))),
   );
-  return matchesAny(added, QUERY_CODE_PATTERNS);
+  for (const { name, pattern } of QUERY_CODE_RULES) {
+    const match = added.match(pattern);
+    if (!match || match.index === undefined) continue;
+    return {
+      rule: name,
+      line: added.slice(0, match.index).split("\n").length,
+      matched: match[0]
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, MATCH_EXCERPT_LIMIT),
+    };
+  }
+  return null;
+}
+
+/** True when the diff's *added* lines contain query code. */
+export function patchAddsQueryCode(patch: string | undefined): boolean {
+  return findQueryCode(patch) !== null;
 }
 
 /**

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -50,6 +50,7 @@ const SOURCE_FILE_PATTERNS = [
 // high-precision ORM / query-builder calls; a small set of raw-SQL shapes
 // catches string queries. Comment lines are stripped before matching, so a
 // code comment mentioning "select" won't trip it.
+//
 // Each rule carries a stable name. The name is the whole point: it is what a
 // reader sees when the gate flags their file, and what a bug report can cite.
 // Six precision fixes so far were each diagnosed by rebuilding, by hand, which
@@ -244,6 +245,17 @@ export interface QuerySiteEvidence {
   matched: string;
 }
 
+/** A changed file the gate reads as a query site, and why. */
+export interface FlaggedFile {
+  path: string;
+  /**
+   * Which rule matched and where. Absent when GitHub supplied no patch (large
+   * or binary file) and the filename prior decided instead — there is no
+   * matched text to point at.
+   */
+  evidence?: QuerySiteEvidence;
+}
+
 /** How much matched text to carry into the verdict. */
 const MATCH_EXCERPT_LIMIT = 120;
 
@@ -284,16 +296,21 @@ export function patchAddsQueryCode(patch: string | undefined): boolean {
  * available; falls back to the filename prior only when the patch is missing
  * (large/binary files), where content can't be inspected.
  */
-function changedQueryCode(
-  file: ChangedFile,
-): boolean {
-  if (!matchesAny(file.path, SOURCE_FILE_PATTERNS)) return false;
+function changedQueryCode(file: ChangedFile): FlaggedFile | null {
+  if (!matchesAny(file.path, SOURCE_FILE_PATTERNS)) return null;
   // A migration `.sql` is schema DDL, not a query site. Its `CREATE/ALTER TABLE`
   // would match the DDL query pattern, but there is no co-located test to link it
   // to, so treating it as changed query code false-positives on every migration.
-  if (matchesAny(file.path, MIGRATION_FILE_PATTERNS)) return false;
-  if (file.patch !== undefined) return patchAddsQueryCode(file.patch);
-  return matchesAny(file.path, DATA_ACCESS_PATH_PATTERNS);
+  if (matchesAny(file.path, MIGRATION_FILE_PATTERNS)) return null;
+  if (file.patch !== undefined) {
+    const evidence = findQueryCode(file.patch);
+    return evidence ? { path: file.path, evidence } : null;
+  }
+  // No patch: GitHub omits it for large or binary files, so there is no text to
+  // match and no evidence to show. The filename prior decides alone.
+  return matchesAny(file.path, DATA_ACCESS_PATH_PATTERNS)
+    ? { path: file.path }
+    : null;
 }
 
 /** A test counts as a data-layer test if it exercises query code or is named like one. */
@@ -335,8 +352,8 @@ function isRelated(dataAccessPath: string, testPath: string): boolean {
 }
 
 export interface ChangedSurface {
-  /** Non-test files whose diff added/altered query code. */
-  dataAccessChanged: string[];
+  /** Non-test files whose diff added/altered query code, with why each matched. */
+  dataAccessChanged: FlaggedFile[];
   /** Real-DB data-layer tests the PR added or changed. */
   dataLayerTestChanged: string[];
 }
@@ -344,14 +361,15 @@ export interface ChangedSurface {
 export function classifyChangedFiles(
   files: ChangedFile[],
 ): ChangedSurface {
-  const dataAccessChanged: string[] = [];
+  const dataAccessChanged: FlaggedFile[] = [];
   const dataLayerTestChanged: string[] = [];
   for (const file of files) {
     if (!isChanged(file.status)) continue;
     if (isTestFile(file.path)) {
       if (isDataLayerTest(file)) dataLayerTestChanged.push(file.path);
-    } else if (changedQueryCode(file)) {
-      dataAccessChanged.push(file.path);
+    } else {
+      const flagged = changedQueryCode(file);
+      if (flagged) dataAccessChanged.push(flagged);
     }
   }
   return { dataAccessChanged, dataLayerTestChanged };
@@ -370,7 +388,7 @@ export interface TestPresenceVerdict {
   nextStep: string;
   triageHint: string;
   /** The changed data-access files with no related data-layer test — what to cover. */
-  dataAccessFiles: string[];
+  dataAccessFiles: FlaggedFile[];
 }
 
 const REASON =
@@ -412,7 +430,7 @@ export function evaluateTestPresence(
   const { dataAccessChanged, dataLayerTestChanged } =
     classifyChangedFiles(files);
   const untested = dataAccessChanged.filter(
-    (path) => !dataLayerTestChanged.some((test) => isRelated(path, test)),
+    (file) => !dataLayerTestChanged.some((test) => isRelated(file.path, test)),
   );
   if (untested.length === 0) return null;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -309,7 +309,13 @@ async function runInCI(
     // as "could not verify", never "your query is broken".
     if (reportContext.testPresenceVerdict) {
       const verdict = reportContext.testPresenceVerdict;
-      const files = verdict.dataAccessFiles.map((f) => `  - ${f}`).join("\n");
+      const files = verdict.dataAccessFiles
+        .map((f) =>
+          f.evidence
+            ? `  - ${f.path} — matched ${f.evidence.rule} on line ${f.evidence.line}: ${f.evidence.matched}`
+            : `  - ${f.path}`,
+        )
+        .join("\n");
       const message =
         `${verdict.reason}\n\nNext step: ${verdict.nextStep}\n\n` +
         `Changed data-access files with no related data-layer test:\n${files}`;

--- a/src/reporters/github/github.test.ts
+++ b/src/reporters/github/github.test.ts
@@ -905,7 +905,12 @@ describe("test-presence verdict rendering", () => {
     reason: "This PR changes data-access code but could not verify it.",
     nextStep: "Add a repository/integration test that exercises it.",
     triageHint: "Note why on the PR if no test is needed.",
-    dataAccessFiles: ["apps/api/src/users/user.repository.ts"],
+    dataAccessFiles: [
+      {
+        path: "apps/api/src/users/user.repository.ts",
+        evidence: { rule: "db-query-method", line: 1, matched: "db.insert" },
+      },
+    ],
   };
 
   test("renders a blocking caution block, reason, next step, and flagged file — never a Warning heading", () => {

--- a/src/reporters/github/success.md.j2
+++ b/src/reporters/github/success.md.j2
@@ -93,7 +93,11 @@ No baseline found to compare against.
 >
 > Changed data-access files with no related data-layer test:
 {% for f in testPresenceVerdict.dataAccessFiles %}
-> - `{{ f }}`
+{% if f.evidence %}
+> - `{{ f.path }}` — matched `{{ f.evidence.rule }}` on line {{ f.evidence.line }}: `{{ f.evidence.matched }}`
+{% else %}
+> - `{{ f.path }}`
+{% endif %}
 {% endfor %}
 >
 > _{{ testPresenceVerdict.triageHint }}_


### PR DESCRIPTION
## Goal

Make the untested-data-access gate explain itself, so a false positive can be judged from the PR comment instead of by cloning the analyzer.

The gate has taken six precision fixes in four weeks (Query-Doctor/Site#3531, #3550, #3615, #3650, plus two cases nobody filed). Every one was diagnosed the same way: check out the analyzer, write a throwaway script, replay the PR's changed-file list, print which pattern matched what text. The module had that information and discarded it before anyone could see it.

An audit of all 15 PRs the gate has ever fired on, across Site, Nutcracker, this repo and veksen-enterprises/d2armory, found 2 correct flags. One false positive is still open: `apps/api/src/db/test-db.ts` on Query-Doctor/Site#3530 and #3573.

## What

Before, the PR comment listed paths:

> - `apps/api/src/db/test-db.ts`

After, it names the cause:

> - `apps/api/src/db/test-db.ts` — matched `drizzle-init` on line 2: `drizzle(`

That line is enough to see the flag is the testcontainers harness being read as production data access. It is the open false positive above, diagnosed without leaving the PR.

## How

Read `src/gate/test-presence.ts` first, then the two rendering sites.

The 20 anonymous regexes in the content matcher become named rules: `raw-select-from`, `drizzle-sql-tag`, `ddl-create-index`, and so on. `findQueryCode` returns the first that matches, with the line and an excerpt. `patchAddsQueryCode` stays as the boolean form, defined in terms of it. Rule order is precedence, so a line matching both `.execute(` and the raw select shape reports the first, which names the cause better.

Line numbers required a change to the three strippers. They removed comment, import and block-comment text, which shifted every later line, so an offset into the stripped text pointed at the wrong place. They now replace that text with spaces and keep the newlines. This is the one behavioural risk in the change: blanking leaves whitespace where deletion closed the gap, and the raw select shape has a 300-character budget between `select` and `from`, so blanking is marginally more conservative. I checked that against the corpus below.

`dataAccessFiles` becomes `{path, evidence}` rather than strings. Evidence is absent when GitHub supplied no patch, which happens for large and binary files: the filename prior decides those alone, and the line renders as a bare path.

The check annotation in `main.ts` renders separately from the template rather than sharing a formatter. That predates this change and I left it alone.

## Tests

Six new cases in `src/gate/test-presence.test.ts`, each written before its implementation and observed failing:

- rule name and line number for a match
- precedence when several rules match
- correct line number when comment and import lines precede the match, which is what the blanking change buys
- null when nothing matches
- the verdict carries evidence through to what a reader sees
- evidence omitted when the path prior decided it

Full suite 429/429. `npm run typecheck` clean.

Beyond the unit tests, I replayed 42 real PRs from Site, Nutcracker, this repo and d2armory through `classifyChangedFiles`. The set of files classified as data access is identical before and after, so the stripper change altered no outcome. I also rendered the comment for Site#3530 and #3573 through the reporter's own nunjucks config, with a patchless file appended so both branches of the new loop render.

