### PR TITLE
fix(gate): strip a comment that trails code on the same line

### DIFF
--- a/src/gate/test-presence.test.ts
+++ b/src/gate/test-presence.test.ts
@@ -40,6 +40,36 @@ describe("patchAddsQueryCode", () => {
     expect(patchAddsQueryCode(addPatch("const total = items.length + 1;"))).toBe(false);
   });
 
+  test("ignores a comment trailing code on the same line", () => {
+    // This gate flagged its own source. Line stripping only drops lines whose
+    // trimmed text starts with `//`, so a comment after code survived, and
+    // "drizzle sql`...` tag" read as a drizzle tag. Any repo whose comments
+    // discuss SQL hits this.
+    expect(
+      patchAddsQueryCode(addPatch("  /\\bsql`/, // drizzle sql`...` tag")),
+    ).toBe(false);
+    expect(
+      patchAddsQueryCode(addPatch("const n = 1; // then select the rows from cache")),
+    ).toBe(false);
+  });
+
+  test("still detects a query on a line that also carries a comment", () => {
+    // Only the comment goes. The code before it is still inspected.
+    expect(
+      patchAddsQueryCode(addPatch("await db.select().from(users); // list them")),
+    ).toBe(true);
+  });
+
+  test("does not treat a URL in a string as a comment", () => {
+    // `//` inside a string opens no comment. Truncating there would blank real
+    // code that follows it on the same line.
+    expect(
+      patchAddsQueryCode(
+        addPatch('const url = "https://x.dev"; await db.select().from(users);'),
+      ),
+    ).toBe(true);
+  });
+
   test("ignores an import of a component named Select", () => {
     // The Site#3650 false positive: `Select } from "…"` completes the raw
     // `select … from` shape, so importing a UI component read as a query and

--- a/src/gate/test-presence.ts
+++ b/src/gate/test-presence.ts
@@ -153,7 +153,21 @@ function stripBlockComments(text: string): string {
   return text.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, " ");
 }
 
-/** Drop lines that are plainly comments, so prose mentioning SQL keywords doesn't match. */
+/**
+ * A `//` or `--` comment that trails code on the same line, plus everything
+ * after it. The `(?<![:/])` guard keeps `https://…` and `a//b` from reading as
+ * the start of a comment, which would blank real code following a URL.
+ * Deliberately blind to `//` inside a string literal: tracking quote state is
+ * more machinery than this heuristic earns, and the cost is under-firing.
+ */
+const TRAILING_COMMENT = /(?<![:/])(\/\/|--).*$/;
+
+/**
+ * Drop comments, so prose mentioning SQL keywords doesn't match. Whole-line
+ * comments go entirely; a comment trailing code takes only the tail. The gate
+ * flagged its own source before this handled the trailing case: a rule defined
+ * as ``/\bsql`/, // drizzle sql`...` tag`` matched the comment, not the code.
+ */
 function stripCommentLines(text: string): string {
   return text
     .split("\n")
@@ -167,6 +181,7 @@ function stripCommentLines(text: string): string {
         trimmed.startsWith("--")
       );
     })
+    .map((line) => line.replace(TRAILING_COMMENT, ""))
     .join("\n");
 }
 


### PR DESCRIPTION
## Goal

Stop the untested-data-access gate reading a code comment as SQL. This one reddened our own CI: Query-Doctor/analyzer#219 failed on `src/gate/test-presence.ts`, the gate's own source.

Bottom of a three-PR stack. #219 and #220 sit on top and are both red without this.

## What

Before, a comment after code on the same line was matched as if it were code.

The line that failed #219:

```
  /\bsql`/, // drizzle sql`...` tag
```

The gate reported the file as changed data-access code. The regex is not what matched. The trailing comment is: ``sql` `` there is preceded by a space, so the `\bsql` word boundary holds.

After, the comment is stripped and the line reads as nothing.

## How

`stripCommentLines` dropped a line only when its trimmed text started with `//`, `--`, `#`, `*` or `/*`. A comment after code never starts the line, so it survived into the matched text.

The fix also strips from `//` or `--` to the end of a line. `(?<![:/])` guards the two cases where those characters do not open a comment: `https://…` and `a//b`. Without it, a line holding a URL would have everything after the URL blanked, including real code.

A `//` inside a string literal is still read as a comment. Tracking quote state is more machinery than a diff heuristic earns, and the failure direction is under-firing, which is the side this gate already picks.

This is not specific to us. Any repo whose comments discuss SQL hits it.

### Why it landed on #219 in particular

#219 moves the pattern array into module constants without changing its content. A move shows every line as added, and the gate only reads added lines. So a pure code move carrying SQL-ish comments trips the gate even though nothing about the code changed.

## Tests

Three cases in `src/gate/test-presence.test.ts`, written before the fix and observed failing:

- the exact line that reddened #219, plus a plain `const n = 1; // then select the rows from cache`
- a query on a line that also carries a comment, which must still be detected
- a URL in a string on the same line as a query, which must not truncate it

I first wrote this test against the regex literal rather than the comment, and it passed without any fix. That was a tautology: `/\bsql`/` does not match the drizzle-tag rule, because `\b` puts a word character before `sql`. The committed test fails without the fix.

Full suite 426/426. `npm run typecheck` clean.

Replaying 42 PRs from Site, Nutcracker, this repo and veksen-enterprises/d2armory classifies the same files as before, so no detection was lost. Replaying analyzer#219 and #220 through the gate now returns no verdict for either.
