### PR TITLE
feat(gate): let an approved migration clear the schema-drift check

### DIFF
--- a/src/gate/schema-change.test.ts
+++ b/src/gate/schema-change.test.ts
@@ -25,6 +25,28 @@ describe("gateSchemaChange", () => {
     expect(gateSchemaChange({ changed: false })).toBeNull();
   });
 
+  it("passes once someone has approved the migration", () => {
+    expect(gateSchemaChange({ changed: true, approved: true })).toBeNull();
+  });
+
+  it("still blocks a schema change nobody has approved", () => {
+    expect(gateSchemaChange({ changed: true, approved: false })?.conclusion).toBe(
+      "failure",
+    );
+  });
+
+  // An API that predates the field sends no `approved` at all. Reading that as
+  // approved would drop the gate for every repo on an older deployment.
+  it("blocks when the API sends no approval field", () => {
+    expect(gateSchemaChange({ changed: true })?.conclusion).toBe("failure");
+  });
+
+  it("names the tool that clears the gate", () => {
+    expect(gateSchemaChange({ changed: true })!.message).toContain(
+      "approve_schema_change",
+    );
+  });
+
   it("passes when the API returned no schema-change signal", () => {
     expect(gateSchemaChange(null)).toBeNull();
     expect(gateSchemaChange(undefined)).toBeNull();

--- a/src/gate/schema-change.ts
+++ b/src/gate/schema-change.ts
@@ -11,6 +11,13 @@ import { resolveVerdict } from "./policy.ts";
 /** The schema diff the API returns on a run (`runMetadata.schemaChange`). */
 export interface SchemaChangeSignal {
   changed: boolean;
+  /**
+   * Whether someone validated this pull request's migration and the schema has
+   * not moved since (Site#3289). Absent on a Site deployment that predates the
+   * field, and read as unapproved — reading an absent field as approved would
+   * drop the gate for every repo on an older API.
+   */
+  approved?: boolean;
 }
 
 export interface SchemaGateResult {
@@ -20,20 +27,25 @@ export interface SchemaGateResult {
 }
 
 const MESSAGE =
-  "This PR changes the database schema — validate the migration before merge. " +
-  "To stop schema changes from blocking this repo, set the schema-drift check " +
-  "to warn or off in CI settings.";
+  "This PR changes the database schema. Review the migration, then call " +
+  "approve_schema_change({ runId, reason }) and re-run CI; approving does not " +
+  "change a check that has already reported. To stop schema changes blocking " +
+  "this repo, set the schema-drift check to warn or off in CI settings.";
 
 /**
  * Decide the schema-change gate from the API's schema diff and the repo policy.
  * Returns the check outcome when the PR changes the schema and the policy
- * surfaces it, or `null` when there is no change or the policy is `off`.
+ * surfaces it, or `null` when there is no change, the migration is approved, or
+ * the policy is `off`.
  */
 export function gateSchemaChange(
   schemaChange: SchemaChangeSignal | null | undefined,
   config: RepoPolicyConfig = {},
 ): SchemaGateResult | null {
   if (!schemaChange?.changed) return null;
+  // An approved migration has already had the human eyeball this gate exists to
+  // force, so it stops blocking without the repo having to soften the policy.
+  if (schemaChange.approved) return null;
   const { conclusion, surfaced } = resolveVerdict(
     { condition: "schema-drift", verdictClass: "finding" },
     config,

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,8 +289,12 @@ async function runInCI(
           regressedCount: reportContext.comparison?.regressed.length ?? 0,
           newQueryCount: reportContext.comparison?.newQueries.length ?? 0,
           indexedNewQueryCount: eligible.length,
+          // An approved migration is not drift the roll-up should count: a
+          // person has already validated it, so the condition is satisfied
+          // rather than softened.
           schemaChanged:
-            reportContext.runMetadata?.schemaChange?.changed === true,
+            reportContext.runMetadata?.schemaChange?.changed === true &&
+            reportContext.runMetadata.schemaChange.approved !== true,
           untestedDataAccessFileCount:
             reportContext.testPresenceVerdict?.dataAccessFiles.length ?? 0,
           regressionThreshold: config.regressionThreshold,

--- a/src/reporters/site-api.ts
+++ b/src/reporters/site-api.ts
@@ -166,6 +166,12 @@ export interface CiRunMetadata {
     changed: boolean;
     operations: Op[];
     changes?: NamedSchemaChange[];
+    /**
+     * Whether someone validated this pull request's migration and the schema
+     * has not moved since (Site#3289). Absent on a Site API that predates the
+     * field, and read as unapproved so the gate keeps blocking.
+     */
+    approved?: boolean;
   } | null;
 }
 


### PR DESCRIPTION
### Goal

A reviewer can clear the schema gate on a migration they have read. The `schema-drift` gate blocks a pull request that changes the schema so that a person validates the migration, but until now nothing could clear it — a repo either failed every migration or turned the condition off. Query-Doctor/Site#3870 built the half that records the validation. This is the half that acts on it.

That completes Query-Doctor/Site#3289. There is no next step in this repo.

### What

Before: a pull request containing a migration failed this check, and the only way to get it green was to set `schema-drift` to warn or off for the whole repo.

After: a reviewer approves that pull request's migration, re-runs CI, and the check passes. A schema change nobody approved still blocks. Amending the migration withdraws the approval on the Site side, so the check blocks again on the next run.

The check's message changes too. It named the setting that disables the gate, because that was the only way out when it was written. It now names the tool that clears it.

### How

Read `src/gate/schema-change.ts` first; the rest follows from it.

1. `SchemaChangeSignal` gains `approved?: boolean`, and `gateSchemaChange` returns `null` when it is true. That is the line that makes an approval clear the check. It sits after the `changed` guard and before the policy lookup, so an approved migration passes without the repo having to soften its policy.
2. `src/main.ts` — the `evaluateGates` roll-up counted `schemaChange.changed`. It now counts `changed && !approved`, so an approved migration is not drift in the summary either. The separate `gateSchemaChange` call below it already passes the whole signal, so it needed no change.
3. `src/reporters/site-api.ts` — `approved?: boolean` on the run response type, optional in the same way `changes` was added.

An absent `approved` reads as unapproved. A Site deployment that predates the field sends no such key, and reading that as approved would drop the gate for every repo on an older API. A test pins that.

Note the field is on Site's `staging` and not yet on `main`, so this has no effect against production until Site deploys. Merging it early is safe: without the field, every run behaves exactly as it does today.

### Tests

`src/gate/schema-change.test.ts` gains five cases: an approved migration passes, an unapproved one still fails, an absent field still fails, and the message names `approve_schema_change`. The existing five cases are unchanged, which is the evidence that the default path did not move.

Two of the five failed before the change. Deleting the approval guard turns "passes once someone has approved the migration" red.

Full suite 440 passed, `tsc --noEmit` clean, `npm run build` succeeds.

The `src/main.ts` call site is not covered. `evaluateGates` is tested in `src/gate/evaluate.test.ts`, but the wiring that feeds it lives in `main.ts`, which has no test harness. The `gateSchemaChange` path that decides the check itself is fully covered.
