### PR TITLE
chore(deps): adopt @query-doctor/core ^0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.20.0",
+        "@query-doctor/core": "^0.21.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.20.0.tgz",
-      "integrity": "sha512-EAs05NoLcB1L9uNlZgpzPU1zZ/V3+M0pRi8/x1cZAS1Fi9Pkkz9dvM4aDgqOR8J5dBNRIoxZIl+MKBt20BV1uA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.21.0.tgz",
+      "integrity": "sha512-cD4FuEGN5endFxmjPiiVQ9Z9EVC9fhd9vZuVJyAVYda0ki92y3b/K9Q/6gF39OA/G2Bf4wwa7OtDZPSw+J4u7g==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.20.0",
+    "@query-doctor/core": "^0.21.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
### Goal

The analyzer resolves `@query-doctor/core` from npm, which served 0.20.0 while seven commits sat unpublished on Site's staging. Query-Doctor/Site#3877 published 0.21.0. This adopts it.

### What

Three of the seven commits change work the analyzer does: the workflow `setup_ci` emits, the echoed-argument detection, and where `LIMIT_WITHOUT_ORDER_BY` is reported. Until this lands, the analyzer runs without them.

### How

`package.json` moves from `^0.20.0` to `^0.21.0`, and `package-lock.json` resolves to `0.21.0`. Nothing else changes.

0.21.0 is a minor rather than a patch because `packages/core/src/index.ts` gained two export lines since 0.20.0, `./sql/pg-stat-statements.js` and `./ci/workflow-template.js`. A caret on `0.20.0` stops below `0.21.0`, so the range had to move.

### Tests

`npm run typecheck` clean. Full suite 436 passed across 43 files, against the published 0.21.0 rather than a workspace copy.
