### PR TITLE
chore(deps): adopt @query-doctor/core ^0.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.21.0",
+        "@query-doctor/core": "^0.22.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.21.0.tgz",
-      "integrity": "sha512-cD4FuEGN5endFxmjPiiVQ9Z9EVC9fhd9vZuVJyAVYda0ki92y3b/K9Q/6gF39OA/G2Bf4wwa7OtDZPSw+J4u7g==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.22.0.tgz",
+      "integrity": "sha512-pUVHqWrtqVRh/495FY/29BpPELXMcmpdAfeRKwmz4DgAYP9m+t7rMtdipPGCPAtUIYExdXO4dqJjuJjcKuevdA==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.21.0",
+    "@query-doctor/core": "^0.22.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
## Goal

Deliver expression index recommendations to CI users. The engine change landed in Query-Doctor/Site#3881 and published as `@query-doctor/core@0.22.0`; nothing reaches a CI run until the analyzer resolves that version. This is the last step.

## What

A query filtering on a function now gets an index recommendation. `WHERE lower(email) = $1` previously produced no recommendation and only a warning saying a function on a column prevents index usage. It now produces `CREATE INDEX ON users ((lower(email)))`, costed against the planner like any other recommendation. The same holds for `btrim`, `md5`, `length`, `substring`, `||`, and `coalesce`.

`coalesce(nickname, email) = $1` previously produced separate recommendations for `nickname` and `email`, neither of which can serve that predicate. It now produces one expression index.

Two fixes come with it. An index recommendation could be hidden: a plain composite reported that it covered an expression index on the same leading column, which it cannot serve. And an optimization could fail outright, because Postgres refuses to index an expression whose function is not `IMMUTABLE` and that refusal aborted the transaction.

## How

A version bump and a lockfile refresh. No analyzer code changes.

The caret had to move rather than resolve on its own: `^0.21.0` does not admit `0.22.0`.

Worth knowing for this repo specifically: core now states on `PostgresTransaction` that a failed `exec` rolls back on its own and later execs still run. `src/sql/postgresjs.ts` already satisfies that, since it wraps every statement in a savepoint — behaviour inherited from postgres.js and reimplemented by hand in `90c05fd` during the move to `pg`. Core no longer takes savepoints of its own, so that adapter is now the only thing providing the guarantee here. An adapter added later has to do the same or use `withStatementIsolation` from core.

## Tests

Full suite passes against `0.22.0`: 43 files, 440 tests. Build clean.

The Site-side `analyzer-compat` check ran this repo's suite against the new core throughout #3881 and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)