### PR TITLE
chore(deps): adopt @query-doctor/core ^0.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.22.0",
+        "@query-doctor/core": "^0.23.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.22.0.tgz",
-      "integrity": "sha512-pUVHqWrtqVRh/495FY/29BpPELXMcmpdAfeRKwmz4DgAYP9m+t7rMtdipPGCPAtUIYExdXO4dqJjuJjcKuevdA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.23.0.tgz",
+      "integrity": "sha512-AqMMww0QEJgxCbqY1ipvmoj/aMc8ATt82o6ayTaxN9VJB1bx69WSszXgvHHx6f1GJxmebI9fcduBS1DYhpga4w==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.22.0",
+    "@query-doctor/core": "^0.23.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
### Goal

Get the analyzer onto the core it needs to dump a schema correctly. Follows [Query-Doctor/Site#3925](https://github.com/Query-Doctor/Site/pull/3925), which published `@query-doctor/core@0.23.0`. This is the last step; nothing else is waiting on it.

### What

Before: on 0.22.0, `dumpSchema` runs SQL whose `CASE con.contype` resolves to the `char` type, so every constraint name is cut to its first character. `primary_key` is dumped as `p` and `foreign_key` as `f`. Any consumer matching on the full name sees nothing.

After: constraint names arrive whole.

### How

The range moves from `^0.22.0` to `^0.23.0`, and the lockfile follows. No source changes.

0.23.0 also maps the old one-character codes back to names when it parses a snapshot, so schemas dumped by an analyzer still on 0.22.0 keep reading correctly. That is what makes this bump safe to land on its own schedule rather than in lockstep with anything.

### Tests

No behavior in this repo changed, so no test was added. `npm test` passes locally against 0.23.0: 440 tests across 43 files, including the runs that dump a real Postgres schema in a container. `tsc --noEmit` is clean.