### PR TITLE
chore(deps): bump @query-doctor/core to 0.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.23.0",
+        "@query-doctor/core": "^0.24.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.23.0.tgz",
-      "integrity": "sha512-AqMMww0QEJgxCbqY1ipvmoj/aMc8ATt82o6ayTaxN9VJB1bx69WSszXgvHHx6f1GJxmebI9fcduBS1DYhpga4w==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.24.0.tgz",
+      "integrity": "sha512-2By0a+jXekur7jkVqjH1kMKC729+tIFF5Ywm3OqbN7JnWSVJNjMzSXmW6B8vG6sPeKRm6SFmETYmfJXylba0xg==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.23.0",
+    "@query-doctor/core": "^0.24.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
### Goal

Make CI runs collect the per-column width measurement that `@query-doctor/core@0.24.0` added. Nothing collects it today, so every payload the API computes stays unmeasured.

Site side: [Query-Doctor/Site#3951](https://github.com/Query-Doctor/Site/pull/3951) is the feature, [#3953](https://github.com/Query-Doctor/Site/pull/3953) published core.

### What

Before, a statistics dump carried `stawidth`, which reports the stored datum — for a TOASTed jsonb that is a pointer, 18 bytes for a column holding 46 KB of JSON.

After, it also carries `avgSerializedBytes` per TOAST-eligible column, sampled with `avg(octet_length(col::text))` under a statement timeout, degrading to unmeasured rather than slowing the dump.

No analyzer code changes. `Statistics.dumpStats` already does this work; the range bump is what lets a run see the version that has it.

### How

`"@query-doctor/core": "^0.23.0"` becomes `"^0.24.0"`, with the lockfile. A `0.x` caret does not cross a minor, so the old range would never have taken 0.24.0.

### Tests

No new test — no analyzer code changed. Existing suite passes: 440 tests across 43 files. Typecheck and build clean.
