### PR TITLE
chore(deps): bump @query-doctor/core to 0.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.24.0",
+        "@query-doctor/core": "^0.25.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.24.0.tgz",
-      "integrity": "sha512-2By0a+jXekur7jkVqjH1kMKC729+tIFF5Ywm3OqbN7JnWSVJNjMzSXmW6B8vG6sPeKRm6SFmETYmfJXylba0xg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.25.0.tgz",
+      "integrity": "sha512-NmiR3Fd3z+2E02J1ckUq5FtEh9si1Jldp9mDRmB//L9zEJNgWCfRM0ULECTzzBV+UzRFPls01fehgPxJ8WIEJw==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.24.0",
+    "@query-doctor/core": "^0.25.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
### Goal

Make CI runs collect the per-column extremes that `@query-doctor/core@0.25.0` added. Nothing collects them today, so a payload is still a point estimate from a mean and an index candidate is never checked for width.

Site side: [Query-Doctor/Site#3955](https://github.com/Query-Doctor/Site/pull/3955) is the feature, [#3961](https://github.com/Query-Doctor/Site/pull/3961) published core.

### What

Before, a statistics dump carried a column's average serialized size. After, it also carries the widest value the sample saw, serialized and as stored.

Two things use them. A payload becomes a range: on this repo's own history query the mean gives 448 KB and the same column's maximum gives 42.5 MB. And a candidate index on a column over 2,704 stored bytes is dropped, because Postgres refuses that key — `index row requires 1152048 bytes, maximum size is 8191` on a real row of `ci_runs_queries.optimization`.

No analyzer code changes. `Statistics.dumpStats` already does the sampling; the range bump is what lets a run see the version that measures both extremes.

### How

`"@query-doctor/core": "^0.24.0"` becomes `"^0.25.0"`, with the lockfile. A `0.x` caret does not cross a minor.

### Tests

No new test, since no analyzer code changed. Existing suite passes: 440 tests across 43 files. Typecheck and build clean.
