### PR TITLE
feat(remote): report why the relay connection died

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { resolveVerdict } from "./gate/policy.ts";
 import { DEFAULT_CONFIG } from "./config.ts";
 import { ApiClient } from "./remote/api-client.ts";
 import { Remote } from "./remote/remote.ts";
+import { watchEventLoopLag } from "./remote/event-loop-lag.ts";
 import { ConnectionManager } from "./sync/connection-manager.ts";
 import { PgbadgerSource } from "./sql/pgbadger.ts";
 import { baselineNotFoundMessage } from "./reporters/baseline-notice.ts";
@@ -438,6 +439,9 @@ async function runOutsideCI() {
     { disableQueryLoader: false },
     sourceDb,
   );
+  // Only the persistent analyzer holds a connection long enough for a stall to
+  // cost it one; a CI run's session is over in seconds.
+  watchEventLoopLag();
   ApiClient.connectWithReconnect(env.SITE_API_ENDPOINT, env.TOKEN, { kind: "persistent" }, remote);
   const server = await createServer(
     env.HOST,

--- a/src/remote/api-client.ts
+++ b/src/remote/api-client.ts
@@ -93,7 +93,18 @@ export class ApiClient extends RpcTarget implements ClientApi {
 
   static async connect(endpoint: string, token: string, mode: ConnectionMode, remote: Remote, onBroken: (err: unknown) => void): Promise<ApiConnection> {
     const wsEndpoint = `${endpoint}/relay`.replace(/^http/, "ws");
-    const unauthenticated = newWebSocketRpcSession<UnauthenticatedServerApi>(wsEndpoint);
+    // Own the socket rather than letting capnweb open it from the URL, so the
+    // close frame is visible. capnweb reports every death as the same
+    // "WebSocket connection failed", which cannot distinguish the server
+    // reaping us as a half-open client (1006, no reason) from a normal close.
+    const socket = new WebSocket(wsEndpoint);
+    socket.addEventListener("close", (event) => {
+      log.info(
+        `Relay socket closed: code=${event.code} reason="${event.reason}" clean=${event.wasClean}`,
+        this.#name,
+      );
+    });
+    const unauthenticated = newWebSocketRpcSession<UnauthenticatedServerApi>(socket);
     const api = await unauthenticated.authenticate(token, new this(remote), mode) as unknown as RpcStub<ServerApi>;
     let broken = false;
     const triggerBroken = (err: unknown) => {

--- a/src/remote/event-loop-lag.ts
+++ b/src/remote/event-loop-lag.ts
@@ -1,0 +1,39 @@
+import { log } from "../log.ts";
+
+const TICK_MS = 1_000;
+const DEFAULT_THRESHOLD_MS = 5_000;
+
+/**
+ * Warns when the event loop stops turning.
+ *
+ * The relay's pong is answered by the transport, on this same loop, and the
+ * server reaps any client that misses one 30-second heartbeat. So a stall here
+ * is indistinguishable — from the server's side — from a process that has died,
+ * and it is the difference between a connection that lasts and one that is
+ * terminated every minute. Nothing else in the analyzer's logs shows it: the
+ * connection simply reports itself broken, with no hint that this process was
+ * the one that went quiet.
+ *
+ * Cheap by construction: one timer, one subtraction per second, and it never
+ * holds the process open.
+ */
+export function watchEventLoopLag(
+  thresholdMs: number = DEFAULT_THRESHOLD_MS,
+): () => void {
+  let previousTick = Date.now();
+  const timer = setInterval(() => {
+    const now = Date.now();
+    // Anything beyond the interval itself is time the loop owed this timer and
+    // could not pay, which is time it could not have answered a ping in either.
+    const lag = now - previousTick - TICK_MS;
+    previousTick = now;
+    if (lag >= thresholdMs) {
+      log.warn(
+        `Event loop stalled for ${(lag / 1000).toFixed(1)}s — the relay could not answer a heartbeat while it was blocked`,
+        "event-loop",
+      );
+    }
+  }, TICK_MS);
+  timer.unref();
+  return () => clearInterval(timer);
+}


### PR DESCRIPTION
### Goal

The persistent analyzer's connection to the relay breaks and reconnects roughly every 65 seconds, and has done for at least 19 days. Neither side records why. This PR adds the two lines needed to find out. It changes no behaviour and fixes nothing on its own.

The follow-up is the delivery fix in the PR stacked on top of this one, which stops a push lost to that connection from being recorded as delivered.

### What

Before: a broken connection logged `Connection broken: Error: WebSocket connection failed.` and nothing else. That message is the same whether the server terminated the client, the network dropped, or the process closed the socket itself.

After: the WebSocket close code and reason are logged alongside it. A stalled event loop is reported once it passes five seconds.

### How

`ApiClient.connect` now constructs the `WebSocket` and hands it to capnweb, instead of passing a URL string for capnweb to open. That is the only way to see the close frame, since capnweb collapses every failure into one message. Verified against `api.querydoctor.com` that capnweb drives a caller-constructed socket: the server's auth check replies in 1.2s.

`watchEventLoopLag` is a one-second interval that measures its own drift. It exists because the relay's pong is answered by the transport on the same event loop, and the server terminates any client that misses one 30-second heartbeat. A process pinned by CPU work is therefore indistinguishable, from the server's side, from one that has died, and nothing currently records the difference. It runs only on the persistent path, holds the process open via `unref`, and costs one subtraction per second.

### Tests

No new tests. Both changes are log lines, and the one behavioural risk — whether capnweb accepts a socket it did not open — was checked against production rather than mocked.

Existing suite passes: 440 tests across 43 files. `npm run typecheck` and `npm run build` are clean.

What these lines are expected to show, once deployed: a close code of 1006 with an empty reason at each break, preceded by an event-loop stall over 30 seconds. If the stall is absent, the diagnosis is wrong and the cause is on the network rather than in the process.