### PR TITLE
feat(remote): say why a statistics refresh was skipped

### DIFF
--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -25,6 +25,8 @@ import { QueryLoader } from "./query-loader.ts";
 import { SchemaLoader } from "./schema-loader.ts";
 import {
   baselineFromDump,
+  DEFAULT_REFRESH_FLOOR_MS,
+  DEFAULT_SIZE_DRIFT_RATIO,
   detectDrift,
   isPastRefreshFloor,
   type StatsBaseline,
@@ -94,6 +96,19 @@ export class Remote extends EventEmitter<RemoteEvents> {
   private statsBaseline?: StatsBaseline;
   /** Guards against a second drift dump starting while one is in flight. */
   private refreshingStats = false;
+  /** When the in-flight refresh started, so a wedged one can say how long. */
+  private refreshingSince?: number;
+  /**
+   * The last reason a poll declined to refresh, and when it was reported.
+   *
+   * The check runs every 60s and almost always declines, so reporting each one
+   * would bury the log. Reporting only changes would hide a steady state from
+   * any window that opens after it settled, which is exactly the position a
+   * five-day statistics gap left us in. Both, then: on change, and on a slow
+   * heartbeat.
+   */
+  private lastSkippedRefresh?: { reason: string; loggedAt: number };
+  private static readonly SKIP_LOG_INTERVAL_MS = 30 * 60 * 1000;
   /**
    * When this analyzer last pushed a dump, for the daily floor. A drift-
    * triggered push updates it too, so the two triggers can't dump twice in
@@ -406,23 +421,57 @@ export class Remote extends EventEmitter<RemoteEvents> {
    * production statistics.
    */
   private async refreshStatsIfStale(source: Connectable): Promise<void> {
-    if (!this.statsBaseline || this.refreshingStats) {
+    if (!this.statsBaseline) {
+      this.noteSkippedRefresh(
+        "no drift baseline, so nothing can trigger a dump",
+      );
+      return;
+    }
+    if (this.refreshingStats) {
+      this.noteSkippedRefresh(
+        `a refresh has been in flight for ${
+          since(this.refreshingSince)
+        }; nothing else can start while it is`,
+      );
       return;
     }
     // Back off after a failure. `lastStatsPushAt` only advances on success, so
     // without this a dump that keeps throwing (a statement_timeout on a large
     // pg_statistic read, say) would be retried on every 60s poll.
     if (this.retryStatsAfter !== undefined && Date.now() < this.retryStatsAfter) {
+      this.noteSkippedRefresh(
+        `backed off for another ${
+          duration(this.retryStatsAfter - Date.now())
+        } after a failed refresh`,
+      );
       return;
     }
     const connector = this.sourceManager.getConnectorFor(source);
     const reltuples = await connector.getReltuplesByTable();
     const verdict = detectDrift(this.statsBaseline, { reltuples });
-    const pastFloor = isPastRefreshFloor(this.lastStatsPushAt, Date.now());
+    const now = Date.now();
+    const pastFloor = isPastRefreshFloor(this.lastStatsPushAt, now);
     if (!verdict.drifted && !pastFloor) {
+      // The near-miss matters: a table sitting just under the ratio means the
+      // threshold is what is holding the refresh back, not a quiet database.
+      const closest = verdict.closest
+        ? `closest was ${verdict.closest.table} at ${
+          Math.round(verdict.closest.ratio * 100)
+        }% of ${Math.round(DEFAULT_SIZE_DRIFT_RATIO * 100)}%`
+        : "no table was eligible";
+      this.noteSkippedRefresh(
+        `no drift (${closest}), and ${
+          this.lastStatsPushAt === undefined
+            ? "the daily floor is unarmed"
+            : `${
+              duration(DEFAULT_REFRESH_FLOOR_MS - (now - this.lastStatsPushAt))
+            } until the daily floor`
+        }`,
+      );
       return;
     }
 
+    this.refreshingSince = Date.now();
     this.refreshingStats = true;
     try {
       log.info(
@@ -441,6 +490,26 @@ export class Remote extends EventEmitter<RemoteEvents> {
     } finally {
       this.refreshingStats = false;
     }
+  }
+
+  /**
+   * Reports why a poll declined to refresh the statistics.
+   *
+   * Every early return above used to be silent, so a project that had not
+   * captured statistics for days looked identical in the logs to one that
+   * refreshed on schedule.
+   */
+  private noteSkippedRefresh(reason: string): void {
+    const now = Date.now();
+    const last = this.lastSkippedRefresh;
+    if (
+      last && last.reason === reason &&
+      now - last.loggedAt < Remote.SKIP_LOG_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.lastSkippedRefresh = { reason, loggedAt: now };
+    log.info(`Statistics refresh skipped: ${reason}`, "remote");
   }
 
   private async dumpSourceStats(source: Connectable): Promise<StatisticsMode> {
@@ -643,3 +712,15 @@ const PgStatStatementsStatus = {
 
 type PgStatStatementsStatus =
   typeof PgStatStatementsStatus[keyof typeof PgStatStatementsStatus];
+
+/** Rounded to the largest unit that still reads as a number, for log lines. */
+function duration(ms: number): string {
+  if (ms <= 0) return "0s";
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+function since(startedAt: number | undefined): string {
+  return startedAt === undefined ? "an unknown time" : duration(Date.now() - startedAt);
+}

--- a/src/remote/stats-drift.test.ts
+++ b/src/remote/stats-drift.test.ts
@@ -178,3 +178,35 @@ describe("isPastRefreshFloor", () => {
     expect(isPastRefreshFloor(NOW - 500, NOW, 1_000)).toBe(false);
   });
 });
+
+/**
+ * A refresh that never fires reads the same from outside whether the database
+ * is quiet or one table is sitting just under the ratio. The first calls for
+ * patience and the second for a different threshold, so the verdict carries the
+ * near miss.
+ */
+describe("detectDrift — the closest table that did not drift", () => {
+  it("names the table nearest the ratio, and how far it moved", () => {
+    const baseline = baselineFromDump([table("users", BIG), table("teams", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG * 0.6, teams: BIG * 0.95 }),
+    });
+
+    expect(verdict.drifted).toBe(false);
+    // users moved 40%, teams 5%. The threshold is 50%, so neither fires.
+    expect(verdict.drifted === false && verdict.closest).toEqual({
+      table: "public.users",
+      ratio: expect.closeTo(0.4, 5),
+    });
+  });
+
+  it("reports no closest table when none was eligible", () => {
+    // Both sides below the row floor, so Size Drift never considers them.
+    const baseline = baselineFromDump([table("tiny", 10)]);
+
+    const verdict = detectDrift(baseline, { reltuples: reltuples({ tiny: 900 }) });
+
+    expect(verdict.drifted === false && verdict.closest).toBeUndefined();
+  });
+});

--- a/src/remote/stats-drift.ts
+++ b/src/remote/stats-drift.ts
@@ -34,7 +34,13 @@ export interface SourceReltuples {
 }
 
 export type DriftVerdict =
-  | { drifted: false }
+  /**
+   * `closest` is the table that came nearest to the ratio without reaching it,
+   * absent when no table was eligible. A refresh that never fires looks the
+   * same from outside whether nothing moved or one table sat just under the
+   * threshold, and those call for opposite fixes.
+   */
+  | { drifted: false; closest?: { table: TableKey; ratio: number } }
   | { drifted: true; kind: "shape" | "size"; reason: string };
 
 /**
@@ -116,6 +122,7 @@ export function detectDrift(
     };
   }
 
+  let closest: { table: TableKey; ratio: number } | undefined;
   for (const [key, now] of current.reltuples) {
     const before = baseline.reltuples.get(key);
     if (before === undefined) continue;
@@ -133,9 +140,12 @@ export function detectDrift(
         }%)`,
       };
     }
+    if (!closest || moved > closest.ratio) {
+      closest = { table: key, ratio: moved };
+    }
   }
 
-  return { drifted: false };
+  return { drifted: false, closest };
 }
 
 function summarize(keys: TableKey[]): string {


### PR DESCRIPTION
Follow-up to #229. Same shape: observability only, no behaviour change.

### Goal

The `site` project went five days without a production-statistics capture. #229 made the relay connection explain itself; this makes the statistics refresh do the same, so the next gap is diagnosable from one poll cycle instead of from inference.

### What

Before: `refreshStatsIfStale` runs on every 60-second schema poll and has four ways to decline, all silent. An analyzer that had not captured statistics for days produced exactly the same log output as one refreshing on schedule.

After: each early return says which guard stopped it, and carries the number that matters.

```
Statistics refresh skipped: no drift (closest was public.project_queries at 42% of 50%), and 6.7h until the daily floor
Statistics refresh skipped: a refresh has been in flight for 4.2h; nothing else can start while it is
Statistics refresh skipped: backed off for another 11m after a failed refresh
Statistics refresh skipped: no drift baseline, so nothing can trigger a dump
```

### How

Read `src/remote/stats-drift.ts` first. `detectDrift`'s not-drifted verdict now carries `closest`, the table that came nearest the ratio without reaching it. A refresh that never fires reads the same from outside whether the database is quiet or one table is sitting just under the threshold, and those call for opposite fixes. On the project that went quiet the closest table was at 42% of a 50% ratio, which is the whole explanation and was invisible.

Then `refreshStatsIfStale` in `src/remote/remote.ts`. The first guard is split so "no baseline" and "already refreshing" report separately, and `refreshingSince` lets the second one say how long — a refresh that never settles wedges that flag for the life of the process, which is a real failure mode with no current symptom.

`noteSkippedRefresh` handles volume. Reporting every poll would add 1,440 lines a day and bury the log, since `log.debug` is not level-gated here. Reporting only changes would hide a steady state from any window that opens after it settled, which is the position the five-day gap left us in. So: on change, then on a 30-minute heartbeat.

### Tests

Two cases in `src/remote/stats-drift.test.ts` cover `closest` — the table nearest the ratio is named with how far it moved, and no table is named when none was eligible for Size Drift.

The log lines themselves are not asserted. They have no callers and no return value, and a test that pins their wording would only restate the string.

Full suite passes: 442 tests across 43 files. `npm run typecheck` and `npm run build` are clean.

### What to look for once deployed

The 2026-08-11 logs show a container that had been up four days, with the daily floor overdue by three, producing no refresh at all. Whether that was a wedged in-flight refresh, an unset baseline, or a schema poll that never fired is still open, and these lines separate the three.