### PR TITLE
chore(deps): adopt @query-doctor/core ^0.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@libpg-query/parser": "^17.6.3",
         "@opentelemetry/api": "^1.9.0",
         "@pgsql/types": "^17.6.2",
-        "@query-doctor/core": "^0.25.0",
+        "@query-doctor/core": "^0.28.0",
         "async-sema": "^3.1.1",
         "capnweb": "^0.7.0",
         "dedent": "^1.7.1",
@@ -1193,9 +1193,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@query-doctor/core": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.25.0.tgz",
-      "integrity": "sha512-NmiR3Fd3z+2E02J1ckUq5FtEh9si1Jldp9mDRmB//L9zEJNgWCfRM0ULECTzzBV+UzRFPls01fehgPxJ8WIEJw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@query-doctor/core/-/core-0.28.0.tgz",
+      "integrity": "sha512-wjlTkfGVdEtvDoyj0uDTORoNyECJtK4yfzEWK7V5uxnj9uN1Xcgt5TJNxIkIjPrZ0i3JRqRG14vKTkw5qUCVAQ==",
       "dependencies": {
         "@pgsql/types": "^17.6.2",
         "capnweb": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@libpg-query/parser": "^17.6.3",
     "@opentelemetry/api": "^1.9.0",
     "@pgsql/types": "^17.6.2",
-    "@query-doctor/core": "^0.25.0",
+    "@query-doctor/core": "^0.28.0",
     "async-sema": "^3.1.1",
     "capnweb": "^0.7.0",
     "dedent": "^1.7.1",


### PR DESCRIPTION
### Goal

A production-statistics capture that contradicts itself should be refused rather than stored. Query-Doctor/Site#3975 added that check and it is live on the API. It cannot fire for captures this analyzer pushes until the analyzer adopts the core that produces the fields it reads.

This is the last step for the relay path.

### What

Before: captures pushed by this analyzer carry no `isPrimary` or `isPartial` on their indexes. The check reads them as unverifiable and stores them, so a capture whose row count contradicts its own primary key is accepted as sound.

After: the dump records both fields, and such a capture is refused at ingest.

### How

The analyzer runs the dump itself, through `Statistics.dumpStats` at `src/remote/remote.ts:523`, so the SQL that reads `pg_index.indisprimary` is this package's copy of core rather than the API's. Nothing in this repo calls the check; adopting the version that emits the fields is the whole change.

0.25.0 to 0.28.0 spans three minors. The only breaking-shaped change is two new optional fields on `ExportedStatsIndex`, which nothing here constructs by hand.

### Tests

No new tests; this is a dependency range and its lockfile.

Existing suite passes: 442 tests across 43 files. `npm run typecheck` and `npm run build` are clean against the new core.

Verified against the installed package that `DUMP_STATS_SQL` now emits `'isPrimary', ix.indisprimary` and `'isPartial', ix.indpred IS NOT NULL`, and that `findDisputedTables` reports the 2026-08-07 shape: `public.project_queries reported 6186 rows against 3626 in its primary key`.