### PR TITLE
fix(remote): earn a statistics re-dump at a fifth, not a half

### DIFF
--- a/src/remote/stats-drift.test.ts
+++ b/src/remote/stats-drift.test.ts
@@ -105,11 +105,26 @@ describe("detectDrift — Size Drift", () => {
     expect(verdict.drifted).toBe(true);
   });
 
-  it("ignores a move below the ratio", () => {
+  it("fires on a quarter-sized move", () => {
+    // A table a quarter bigger than the snapshot has every query against it
+    // costed a quarter light, which is well past what a planner shrugs off.
     const baseline = baselineFromDump([table("users", BIG)]);
 
     const verdict = detectDrift(baseline, {
-      reltuples: reltuples({ users: Math.round(BIG * 1.2) }),
+      reltuples: reltuples({ users: Math.round(BIG * 1.25) }),
+    });
+
+    expect(verdict.drifted).toBe(true);
+  });
+
+  it("ignores a move below the ratio", () => {
+    // One autoanalyze tick. `pg_class.reltuples` only moves when autovacuum
+    // analyzes the table, so a move this size is as likely to be the sampling
+    // catching up as the data actually growing.
+    const baseline = baselineFromDump([table("users", BIG)]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: Math.round(BIG * 1.1) }),
     });
 
     expect(verdict.drifted).toBe(false);
@@ -190,14 +205,14 @@ describe("detectDrift — the closest table that did not drift", () => {
     const baseline = baselineFromDump([table("users", BIG), table("teams", BIG)]);
 
     const verdict = detectDrift(baseline, {
-      reltuples: reltuples({ users: BIG * 0.6, teams: BIG * 0.95 }),
+      reltuples: reltuples({ users: BIG * 0.85, teams: BIG * 0.95 }),
     });
 
     expect(verdict.drifted).toBe(false);
-    // users moved 40%, teams 5%. The threshold is 50%, so neither fires.
+    // users moved 15%, teams 5%. The threshold is 20%, so neither fires.
     expect(verdict.drifted === false && verdict.closest).toEqual({
       table: "public.users",
-      ratio: expect.closeTo(0.4, 5),
+      ratio: expect.closeTo(0.15, 5),
     });
   });
 

--- a/src/remote/stats-drift.ts
+++ b/src/remote/stats-drift.ts
@@ -44,11 +44,21 @@ export type DriftVerdict =
   | { drifted: true; kind: "shape" | "size"; reason: string };
 
 /**
- * Ratio a table's `reltuples` must move by before Size Drift fires. 0.5 means
- * the table has to halve or grow by 50%; below that the planner's choices are
- * unlikely to change enough to be worth a full dump.
+ * Ratio a table's `reltuples` must move by before Size Drift fires. 0.2 means
+ * the table has to grow or shrink by a fifth.
+ *
+ * The floor under this number is the resolution of the signal it reads.
+ * `pg_class.reltuples` is only rewritten when autovacuum analyzes the table,
+ * which by default happens once it has changed by `autovacuum_analyze_scale_
+ * factor` — 10%. A threshold below that would be reading sampling noise rather
+ * than the data moving.
+ *
+ * The ceiling is how wrong a cost may be before it stops being worth
+ * reporting. At the old 0.5 a table could sit half again its snapshot size and
+ * still be called current, so every query against it was costed a third light
+ * — a bigger error than most of what we flag.
  */
-export const DEFAULT_SIZE_DRIFT_RATIO = 0.5;
+export const DEFAULT_SIZE_DRIFT_RATIO = 0.2;
 
 /**
  * Tables smaller than this are exempt from Size Drift. A table going from 2 to


### PR DESCRIPTION
## Goal

Queries should be costed against statistics that match the database they run on. The analyzer keeps a project's stored statistics current by re-dumping when the source has moved; this changes how far it has to move before that happens.

## What

Before: a table had to grow by half, or shrink to half, before the analyzer re-dumped the source's statistics. Between re-dumps a table could sit at 1.5x its recorded size, and every query against it was costed a third light.

After: a fifth of movement is enough. A table at 1.25x its recorded size now earns a re-dump instead of being called current.

The re-dump itself is unchanged, as is the 24-hour floor that fires when nothing has drifted.

## How

`src/remote/stats-drift.ts` is the whole change: `DEFAULT_SIZE_DRIFT_RATIO` goes from 0.5 to 0.2.

The number is bounded on both sides. Underneath, the check reads `pg_class.reltuples`, which Postgres only rewrites when autovacuum analyzes the table, by default once it has changed by `autovacuum_analyze_scale_factor`, 10%. A threshold below that reads sampling noise rather than data. Above, the threshold is how wrong a cost may be before it is worth acting on, and 0.5 tolerated a cost a third light.

0.2 also makes the growth and shrink sides close to even. The comparison is `|now - before| / before`, so 0.5 fired on 1.5x growth but needed a 2x shrink; at 0.2 the two are 1.25x and 1.2x.

## Tests

`src/remote/stats-drift.test.ts`: a 1.25x move drifts, a 1.1x move does not. The near-miss case that names the closest table sits at 15% and 5%, either side of the new threshold.

Full suite passes (443 tests, 43 files), `npm run typecheck` clean.