### PR TITLE
feat(remote): earn a statistics re-dump on an uncovered column

### DIFF
--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -420,7 +420,10 @@ export class Remote extends EventEmitter<RemoteEvents> {
    * baseline for it would push someone else's numbers as this project's
    * production statistics.
    */
-  private async refreshStatsIfStale(source: Connectable): Promise<void> {
+  private async refreshStatsIfStale(
+    source: Connectable,
+    schema?: FullSchema,
+  ): Promise<void> {
     if (!this.statsBaseline) {
       this.noteSkippedRefresh(
         "no drift baseline, so nothing can trigger a dump",
@@ -448,7 +451,7 @@ export class Remote extends EventEmitter<RemoteEvents> {
     }
     const connector = this.sourceManager.getConnectorFor(source);
     const reltuples = await connector.getReltuplesByTable();
-    const verdict = detectDrift(this.statsBaseline, { reltuples });
+    const verdict = detectDrift(this.statsBaseline, { reltuples, schema });
     const now = Date.now();
     const pastFloor = isPastRefreshFloor(this.lastStatsPushAt, now);
     if (!verdict.drifted && !pastFloor) {
@@ -630,9 +633,11 @@ export class Remote extends EventEmitter<RemoteEvents> {
       this.emit("schemaDiffed", diffs, schema);
     });
     // The schema poll is also the drift tick: it already runs every 60s, so
-    // checking here costs one `pg_class` read and no extra schedule.
-    this.schemaLoader.on("polled", () => {
-      this.refreshStatsIfStale(source).catch((error) => {
+    // checking here costs one `pg_class` read and no extra schedule. The schema
+    // it just dumped comes along for the same reason — Shape Drift reads the
+    // columns and indexes off it, which no other signal can see.
+    this.schemaLoader.on("polled", (schema) => {
+      this.refreshStatsIfStale(source, schema).catch((error) => {
         log.error("Failed to check statistics drift", "remote");
         console.error(error);
       });

--- a/src/remote/stats-drift.test.ts
+++ b/src/remote/stats-drift.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { ExportedStats } from "@query-doctor/core";
+import type { ExportedStats, FullSchema } from "@query-doctor/core";
+import { PgIdentifier } from "@query-doctor/core";
 import {
   baselineFromDump,
   detectDrift,
@@ -7,16 +8,60 @@ import {
   SIZE_DRIFT_MIN_ROWS,
 } from "./stats-drift.ts";
 
-function table(name: string, reltuples: number): ExportedStats {
+function table(
+  name: string,
+  reltuples: number,
+  covers?: { columns?: string[] },
+): ExportedStats {
   return {
     schemaName: "public",
     tableName: name,
     reltuples,
     relpages: Math.max(1, Math.round(reltuples / 100)),
     relallvisible: 0,
-    columns: [],
+    // `DUMP_STATS_SQL` reads these from `pg_attribute`, unquoted.
+    columns: (covers?.columns ?? []).map((columnName) => ({ columnName })),
     indexes: [],
   } as unknown as ExportedStats;
+}
+
+/**
+ * A live schema as the 60s poll delivers it: names go through the same
+ * `quote_ident` → `PgIdentifier` path the real dump uses, so a test written
+ * with a raw name exercises whatever escaping that path applies.
+ */
+function schema(
+  tables: {
+    name: string;
+    columns?: (string | { name: string; dropped: boolean })[];
+  }[],
+): FullSchema {
+  const identifier = (raw: string) =>
+    PgIdentifier.fromString(quoteIdent(raw)) as unknown as string;
+  return {
+    tables: tables.map((t) => ({
+      type: "table",
+      schemaName: identifier("public"),
+      tableName: identifier(t.name),
+      columns: (t.columns ?? []).map((column) =>
+        typeof column === "string"
+          ? { type: "column", name: identifier(column), dropped: false }
+          : {
+            type: "column",
+            name: identifier(column.name),
+            dropped: column.dropped,
+          }
+      ),
+    })),
+    indexes: [],
+  } as unknown as FullSchema;
+}
+
+/** `quote_ident`, as the schema dump applies it before we ever see the name. */
+function quoteIdent(raw: string): string {
+  return /^[a-z_][a-z0-9_]*$/.test(raw)
+    ? raw
+    : `"${raw.replaceAll('"', '""')}"`;
 }
 
 function reltuples(entries: Record<string, number>): Map<string, number> {
@@ -78,6 +123,166 @@ describe("detectDrift — Shape Drift", () => {
 
     if (!verdict.drifted) throw new Error("expected drift");
     expect(verdict.kind).toBe("shape");
+  });
+});
+
+/**
+ * A migration that adds a column leaves the table set and every `reltuples`
+ * untouched, so neither of the original two signals sees it. The added column
+ * has no `pg_statistic` row in the snapshot, and nothing synthesizes one for a
+ * table the snapshot already covers — it is costed on the planner's
+ * no-statistics defaults instead.
+ */
+describe("detectDrift — Shape Drift on columns", () => {
+  it("fires when the live schema has a column the snapshot doesn't cover", () => {
+    const baseline = baselineFromDump([
+      table("users", BIG, { columns: ["id", "email"] }),
+    ]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG }),
+      schema: schema([{ name: "users", columns: ["id", "email", "last_seen_at"] }]),
+    });
+
+    expect(verdict.drifted).toBe(true);
+    if (!verdict.drifted) return;
+    expect(verdict.kind).toBe("shape");
+    expect(verdict.reason).toContain("public.users.last_seen_at");
+  });
+
+  it("does not fire once the snapshot covers everything the schema has", () => {
+    // The steady state, and the one that has to hold: a signal that stays lit
+    // after the dump it asked for would re-dump on every 60s poll forever.
+    const baseline = baselineFromDump([
+      table("users", BIG, { columns: ["id", "email"] }),
+    ]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG }),
+      schema: schema([{ name: "users", columns: ["id", "email"] }]),
+    });
+
+    expect(verdict.drifted).toBe(false);
+  });
+
+  it.each([
+    ["camelCase", "lastSeenAt"],
+    ["a reserved word", "user"],
+    ["an embedded double quote", 'we"ird'],
+  ])(
+    "converges on a name needing quotes: %s",
+    (_case, columnName) => {
+      // The snapshot reads `pg_attribute` raw; the schema runs the name through
+      // `quote_ident` and then `PgIdentifier`, which escapes it again. Any name
+      // the two sides can't agree on is a full dump every 60 seconds, forever.
+      const baseline = baselineFromDump([
+        table("users", BIG, { columns: ["id", columnName] }),
+      ]);
+
+      const verdict = detectDrift(baseline, {
+        reltuples: reltuples({ users: BIG }),
+        schema: schema([{ name: "users", columns: ["id", columnName] }]),
+      });
+
+      expect(verdict.drifted).toBe(false);
+    },
+  );
+
+  it("ignores a column flagged dropped, whichever side filters it", () => {
+    // Both dumps filter `attisdropped` today, so this state does not reach us
+    // in practice. The schema carries the flag, and a column missing by
+    // construction would ask for a dump it can never be satisfied by.
+    const baseline = baselineFromDump([
+      table("users", BIG, { columns: ["id"] }),
+    ]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG }),
+      schema: schema([
+        { name: "users", columns: ["id", { name: "legacy", dropped: true }] },
+      ]),
+    });
+
+    expect(verdict.drifted).toBe(false);
+  });
+
+  it("ignores columns on a relation the snapshot never covered", () => {
+    // The table checks own an uncovered table, and they read the `pg_class`
+    // probe rather than the schema. The two disagree on materialized views:
+    // the schema carries them, the probe and the statistics dump don't. Firing
+    // here would ask for a dump that can never satisfy it.
+    const baseline = baselineFromDump([table("users", BIG, { columns: ["id"] })]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG }),
+      schema: schema([
+        { name: "users", columns: ["id"] },
+        { name: "mv_active_users", columns: ["id", "last_seen_at"] },
+      ]),
+    });
+
+    expect(verdict.drifted).toBe(false);
+  });
+
+  it("does not fire when a column is dropped from a covered table", () => {
+    // Deliberate. Restore matches the snapshot against the live relation by
+    // name, so a column that no longer exists matches nothing and costs
+    // nothing. Spending a full dump to delete unread rows is the noise this
+    // signal exists to avoid.
+    const baseline = baselineFromDump([
+      table("users", BIG, { columns: ["id", "email", "legacy_flag"] }),
+    ]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG }),
+      schema: schema([{ name: "users", columns: ["id", "email"] }]),
+    });
+
+    expect(verdict.drifted).toBe(false);
+  });
+
+  it("takes precedence over a simultaneous size change", () => {
+    const baseline = baselineFromDump([
+      table("users", BIG, { columns: ["id"] }),
+    ]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG * 10 }),
+      schema: schema([{ name: "users", columns: ["id", "email"] }]),
+    });
+
+    if (!verdict.drifted) throw new Error("expected drift");
+    expect(verdict.kind).toBe("shape");
+  });
+
+  it("reports an uncovered table ahead of an uncovered column", () => {
+    // Both are true at once: `teams` is new, and `users` gained a column. Only
+    // an order that checks tables first can report the table, so this pins the
+    // order rather than restating it.
+    const baseline = baselineFromDump([table("users", BIG, { columns: ["id"] })]);
+
+    const verdict = detectDrift(baseline, {
+      reltuples: reltuples({ users: BIG, teams: 0 }),
+      schema: schema([
+        { name: "users", columns: ["id", "email"] },
+        { name: "teams", columns: ["id", "name"] },
+      ]),
+    });
+
+    if (!verdict.drifted) throw new Error("expected drift");
+    expect(verdict.reason).toContain("table(s)");
+    expect(verdict.reason).toContain("public.teams");
+    expect(verdict.reason).not.toContain("public.users.email");
+  });
+
+  it("checks nothing when the poll has produced no schema yet", () => {
+    const baseline = baselineFromDump([
+      table("users", BIG, { columns: ["id", "email"] }),
+    ]);
+
+    const verdict = detectDrift(baseline, { reltuples: reltuples({ users: BIG }) });
+
+    expect(verdict.drifted).toBe(false);
   });
 });
 

--- a/src/remote/stats-drift.ts
+++ b/src/remote/stats-drift.ts
@@ -1,4 +1,4 @@
-import type { ExportedStats } from "@query-doctor/core";
+import type { ExportedStats, FullSchema } from "@query-doctor/core";
 
 /**
  * Decides when the production-statistics snapshot the server holds has fallen
@@ -7,15 +7,42 @@ import type { ExportedStats } from "@query-doctor/core";
  * The full `DUMP_STATS_SQL` is expensive, so it is earned by detected change
  * rather than run on a timer. Two signals, both cheap:
  *
- * - **Shape Drift** — the source has tables the last pushed dump doesn't cover,
- *   or has dropped tables it did. Free: the analyzer already polls the schema
- *   every 60s, so this is a set comparison with no extra query.
+ * - **Shape Drift** — the source holds a relation the last pushed dump doesn't
+ *   cover: a table, or a column on a table it does cover. Free: the analyzer
+ *   already polls the schema every 60s, so this is a set comparison with no
+ *   extra query.
  * - **Size Drift** — per-table `reltuples` have moved past a threshold. Costs
  *   one `pg_class` read; never touches `pg_statistic`.
  *
- * Shape Drift is the one that matters most in practice: a table added by a
- * migration has no stats at all, so every query touching it is costed by the
- * synthesizer instead of real data until the snapshot catches up.
+ * Shape Drift is the one that matters most in practice. Anything the snapshot
+ * doesn't cover is costed on estimates rather than measurements: a whole table
+ * goes to the synthesizer, and a column on a covered table goes to the
+ * planner's no-statistics defaults, which nothing synthesizes and nothing
+ * reports.
+ *
+ * Every comparison here is presence-only, and in one direction: the source has
+ * something the snapshot lacks.
+ *
+ * Presence-only because the two sides don't speak the same dialect anywhere
+ * else. A column's type reaches the schema through `format_type` (`character
+ * varying(255)`) and the snapshot through `pg_type.typname` (`varchar`), so
+ * comparing types would call every column changed on every poll. Catching a
+ * type change needs the dump to export `format_type` first.
+ *
+ * One direction because a relation the snapshot covers and the source has
+ * dropped costs nothing: the restore matches the snapshot to the live database
+ * by name, so the extra entry matches nothing. Spending a full dump to delete
+ * rows no query reads is the noise this signal exists to avoid.
+ *
+ * Indexes are deliberately not compared, though the snapshot carries their
+ * names. `DUMP_STATS_SQL` collects them in a CTE filtered by
+ * `relname NOT LIKE 'pg_%'` — where `_` is a wildcard, so a table called
+ * `pgmigrations` or `pgbench_accounts` is exported with its columns and an
+ * empty index list. That table's indexes would read as uncovered after the very
+ * dump that was meant to cover them, which is a full dump every 60 seconds
+ * forever. The same CTE groups by `relname` alone, so same-named tables in
+ * different schemas share one index list and a genuinely new index is masked
+ * anyway. Both are fixable only in the dump.
  */
 
 /** A table's identity in a dump, as `"schema.table"`. */
@@ -26,11 +53,20 @@ export interface StatsBaseline {
   tables: Set<TableKey>;
   /** Their `reltuples` at that moment, for the Size Drift comparison. */
   reltuples: Map<TableKey, number>;
+  /** The column names it covered on each of them, unquoted. */
+  columns: Map<TableKey, Set<string>>;
 }
 
 /** The current cheap reading from the source, for comparison against a baseline. */
-export interface SourceReltuples {
+export interface SourceReading {
   reltuples: Map<TableKey, number>;
+  /**
+   * The live schema from the same poll tick, which carries the columns
+   * `reltuples` alone can't see. Optional: a caller that has no schema yet gets
+   * the table and size checks and skips the rest, rather than reading an absent
+   * schema as an empty database.
+   */
+  schema?: FullSchema;
 }
 
 export type DriftVerdict =
@@ -70,12 +106,26 @@ export const SIZE_DRIFT_MIN_ROWS = 1_000;
 export function baselineFromDump(stats: ExportedStats[]): StatsBaseline {
   const tables = new Set<TableKey>();
   const reltuples = new Map<TableKey, number>();
+  const columns = new Map<TableKey, Set<string>>();
   for (const table of stats) {
     const key = tableKey(table.schemaName, table.tableName);
     tables.add(key);
     reltuples.set(key, table.reltuples);
+    // Every live column, whether or not Postgres has analyzed it — the dump
+    // reads `pg_attribute` and left-joins `pg_statistic`. So a column that has
+    // never been analyzed still lands here, and asking for a dump on its
+    // account would ask forever.
+    //
+    // Defended rather than trusted: a seeded baseline is whatever the server
+    // stored, which for an old enough capture may carry no columns key at all.
+    // Reading that as "covers no columns" earns one re-dump and then converges,
+    // where trusting the type throws inside the poll and no refresh ever runs.
+    columns.set(
+      key,
+      new Set((table.columns ?? []).map((c) => unquote(c.columnName))),
+    );
   }
-  return { tables, reltuples };
+  return { tables, reltuples, columns };
 }
 
 export function tableKey(
@@ -85,20 +135,46 @@ export function tableKey(
   return `${unquote(String(schemaName))}.${unquote(String(tableName))}`;
 }
 
+/**
+ * Undo `quote_ident`, collapsing escaped quotes until the name stops changing.
+ *
+ * The two sides of a comparison reach us in different dialects. The statistics
+ * dump reads `pg_attribute` raw; the schema poll runs `quote_ident` and then
+ * `PgIdentifier` escapes that result a second time, so a column named `we"ird`
+ * arrives as `"we""""ird"` against a raw `we"ird`. Undoing one level leaves
+ * them unequal, and a name that never matches asks for a full dump on every
+ * poll, forever.
+ *
+ * Collapsing to a fixed point lands both dialects on the raw name. It also
+ * makes two names that differ only in how many quotes they contain compare
+ * equal, so a deliberately hostile identifier can read as covered when it
+ * isn't. That costs one missed refresh; the loop it replaces costs a full dump
+ * every 60 seconds.
+ */
 function unquote(identifier: string): string {
-  return identifier.startsWith('"') && identifier.endsWith('"')
-    ? identifier.slice(1, -1)
-    : identifier;
+  if (
+    identifier.length < 2 || !identifier.startsWith('"') ||
+    !identifier.endsWith('"')
+  ) {
+    return identifier;
+  }
+  let value = identifier.slice(1, -1);
+  while (value.includes('""')) {
+    value = value.replaceAll('""', '"');
+  }
+  return value;
 }
 
 /**
- * Compares the source's current table set and row counts against the last dump
- * that was pushed. Shape Drift is checked first: it's free, and a table with no
- * stats at all is a worse problem than one whose count moved.
+ * Compares the source's current shape and row counts against the last dump that
+ * was pushed. Shape Drift is checked first: it's free, and a relation with no
+ * stats at all is a worse problem than one whose count moved. Within it, whole
+ * tables come before columns — a new table's columns are all missing at once,
+ * and "one table is uncovered" is the reason a reader can act on.
  */
 export function detectDrift(
   baseline: StatsBaseline,
-  current: SourceReltuples,
+  current: SourceReading,
   options?: { sizeDriftRatio?: number; minRows?: number },
 ): DriftVerdict {
   const ratio = options?.sizeDriftRatio ?? DEFAULT_SIZE_DRIFT_RATIO;
@@ -132,6 +208,11 @@ export function detectDrift(
     };
   }
 
+  const uncovered = uncoveredColumns(baseline, current.schema);
+  if (uncovered) {
+    return { drifted: true, kind: "shape", reason: uncovered };
+  }
+
   let closest: { table: TableKey; ratio: number } | undefined;
   for (const [key, now] of current.reltuples) {
     const before = baseline.reltuples.get(key);
@@ -156,6 +237,44 @@ export function detectDrift(
   }
 
   return { drifted: false, closest };
+}
+
+/**
+ * Columns the live schema has on a table the snapshot covers, and the snapshot
+ * doesn't. Returns the reason to re-dump, or undefined for none.
+ *
+ * Tables the snapshot doesn't cover at all are skipped: the checks above own
+ * them, and they read the `pg_class` probe rather than the schema. The two
+ * disagree on purpose — the probe is `relkind = 'r'`, while the schema also
+ * carries materialized views, which no statistics dump will ever cover.
+ * Reporting those here would ask for a dump that cannot satisfy it.
+ */
+function uncoveredColumns(
+  baseline: StatsBaseline,
+  schema: FullSchema | undefined,
+): string | undefined {
+  if (!schema) return undefined;
+
+  const columns: string[] = [];
+  for (const table of schema.tables) {
+    const key = tableKey(table.schemaName, table.tableName);
+    const covered = baseline.columns.get(key);
+    if (!covered) continue;
+    for (const column of table.columns) {
+      // Belt and braces: both dumps filter `attisdropped` today, so a dropped
+      // column reaches neither side. Left in because the schema carries the
+      // flag, and a column that is missing by construction would never stop
+      // asking for a dump.
+      if (column.dropped) continue;
+      const name = unquote(String(column.name));
+      if (!covered.has(name)) columns.push(`${key}.${name}`);
+    }
+  }
+  if (columns.length === 0) return undefined;
+
+  return `${columns.length} column(s) not covered by the snapshot: ${
+    summarize(columns)
+  }`;
 }
 
 function summarize(keys: TableKey[]): string {


### PR DESCRIPTION
## Goal

Keep a project's production statistics covering the schema its queries run against, so costs come from measurements rather than defaults. ADR 0007 §2 made a re-dump something a database change earns rather than something a timer runs.

This closes the column-shaped hole in that trigger. The matching index check waits on [Query-Doctor/Site#4005](https://github.com/Query-Doctor/Site/issues/4005) and [Query-Doctor/Site#3959](https://github.com/Query-Doctor/Site/issues/3959).

Closes [Query-Doctor/Site#4003](https://github.com/Query-Doctor/Site/issues/4003). The Site half, an ADR amendment and a glossary entry, is [Query-Doctor/Site#4007](https://github.com/Query-Doctor/Site/pull/4007).

## What

Before: a migration that added a column earned no statistics refresh. The table set was unchanged and no row count moved, so neither drift signal fired. The new column had no `pg_statistic` row, so a query filtering on it was costed at Postgres's `DEFAULT_EQ_SEL` of 0.005 — a fixed guess rather than a reading of production, with nothing in the report marking it as one. The snapshot caught up only on the 24-hour floor.

After: the same migration is detected on the next 60-second poll and earns a re-dump, as a new table does today.

Dropping a column still changes nothing.

## How

Read `src/remote/stats-drift.ts` first. `remote.ts` only passes an argument through.

`detectDrift` compared the set of table keys and per-table `reltuples`, both from one `pg_class` probe. It now also compares column names, against the schema the 60-second poll has already dumped. The baseline reads them from the capture, which exports every live column from `pg_attribute` whether or not Postgres has analyzed it. No new query and no new schedule.

Three limits, each one a path to a full `DUMP_STATS_SQL` every 60 seconds forever:

**Only tables the capture covers.** The probe is `relkind = 'r'`; the schema also carries materialized views, which no capture covers. Reporting one asks for a dump that cannot satisfy it.

**Presence, never types.** A column's type reaches the schema through `format_type` (`character varying(255)`) and the capture through `pg_type.typname` (`varchar`). Comparing them calls every column changed on every poll.

**One direction.** A column the capture covers and the database has dropped is ignored. Restore matches by name, so the extra entry matches nothing.

Names collapse to a fixed point before comparison. The capture reads `pg_attribute` raw; the schema runs `quote_ident`, and `PgIdentifier.toString()` escapes that result again, so `we"ird` arrives as `"we""""ird"`. Undoing one level leaves the two unequal forever.

Indexes are excluded, though the capture carries their names. `DUMP_STATS_SQL` collects them in a CTE filtered by `relname NOT LIKE 'pg_%'`, where `_` is a wildcard, so a table named `pgmigrations` is captured with its columns and an empty index list, and its indexes read as uncovered after the dump meant to cover them. The same CTE groups by `relname` alone, so same-named tables in different schemas share one index list and a real new index is masked. Both are fixable only in the dump.

## Tests

`src/remote/stats-drift.test.ts`, unit level, no database.

Covered: an uncovered column fires; the steady state after a refresh does not; a name needing quotes converges, for camelCase, a reserved word, and an embedded double quote; a dropped column does not fire; a relation the capture never covered does not fire; an uncovered table is reported ahead of an uncovered column; an absent schema checks nothing.

The ordering test and the embedded-quote test both fail against a mutated implementation: check order reversed, and one level of unquoting in place of the fixed point.

`npm run typecheck` clean. 43 files, 454 tests passing, rebased on `main` at `aff59d6`.
